### PR TITLE
Add mandatory phone number with 90-day change restriction

### DIFF
--- a/fraudwallet/backend/src/database.js
+++ b/fraudwallet/backend/src/database.js
@@ -19,6 +19,8 @@ const createUsersTable = () => {
       full_name TEXT NOT NULL,
       email TEXT UNIQUE NOT NULL,
       password_hash TEXT NOT NULL,
+      phone_number TEXT NOT NULL,
+      phone_last_changed DATETIME DEFAULT CURRENT_TIMESTAMP,
       account_status TEXT DEFAULT 'active',
       created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
       updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
@@ -28,17 +30,27 @@ const createUsersTable = () => {
   db.exec(sql);
   console.log('✅ Users table is ready');
 
-  // Add account_status column if it doesn't exist (for existing databases)
+  // Add missing columns if they don't exist (for existing databases)
   try {
     const columns = db.prepare("PRAGMA table_info(users)").all();
-    const hasAccountStatus = columns.some(col => col.name === 'account_status');
+    const columnNames = columns.map(col => col.name);
 
-    if (!hasAccountStatus) {
+    if (!columnNames.includes('account_status')) {
       db.exec("ALTER TABLE users ADD COLUMN account_status TEXT DEFAULT 'active'");
-      console.log('✅ Added account_status column to existing users table');
+      console.log('✅ Added account_status column');
+    }
+
+    if (!columnNames.includes('phone_number')) {
+      db.exec("ALTER TABLE users ADD COLUMN phone_number TEXT");
+      console.log('✅ Added phone_number column');
+    }
+
+    if (!columnNames.includes('phone_last_changed')) {
+      db.exec("ALTER TABLE users ADD COLUMN phone_last_changed DATETIME DEFAULT CURRENT_TIMESTAMP");
+      console.log('✅ Added phone_last_changed column');
     }
   } catch (error) {
-    // Column might already exist, ignore error
+    console.error('Error adding columns:', error.message);
   }
 };
 

--- a/fraudwallet/backend/src/server.js
+++ b/fraudwallet/backend/src/server.js
@@ -39,6 +39,7 @@ const user = require('./user');
 const { verifyToken } = require('./middleware');
 app.get('/api/user/profile', verifyToken, user.getProfile);
 app.put('/api/user/profile', verifyToken, user.updateProfile);
+app.put('/api/user/phone', verifyToken, user.changePhoneNumber);
 app.post('/api/user/terminate', verifyToken, user.terminateAccount);
 
 // Start the server

--- a/fraudwallet/backend/src/validation.js
+++ b/fraudwallet/backend/src/validation.js
@@ -1,0 +1,65 @@
+// Validation utilities
+
+/**
+ * Validate Malaysian phone number
+ * Format: +60 followed by 10-11 digits
+ * Examples: +60123456789, +601234567890
+ */
+const validatePhoneNumber = (phone) => {
+  // Remove spaces and dashes
+  const cleanPhone = phone.replace(/[\s-]/g, '');
+
+  // Check if it starts with +60
+  if (!cleanPhone.startsWith('+60')) {
+    return {
+      valid: false,
+      message: 'Phone number must start with +60 (Malaysia country code)'
+    };
+  }
+
+  // Remove +60 and check remaining digits
+  const digits = cleanPhone.substring(3);
+
+  // Check if it's 10-11 digits
+  if (!/^\d{10,11}$/.test(digits)) {
+    return {
+      valid: false,
+      message: 'Phone number must have 10-11 digits after +60'
+    };
+  }
+
+  return {
+    valid: true,
+    formatted: cleanPhone
+  };
+};
+
+/**
+ * Check if user can change phone number
+ * Users can only change phone once every 90 days
+ */
+const canChangePhone = (lastChangedDate) => {
+  if (!lastChangedDate) {
+    return { canChange: true };
+  }
+
+  const lastChanged = new Date(lastChangedDate);
+  const now = new Date();
+  const daysSinceChange = Math.floor((now - lastChanged) / (1000 * 60 * 60 * 24));
+
+  if (daysSinceChange < 90) {
+    const daysRemaining = 90 - daysSinceChange;
+    return {
+      canChange: false,
+      daysRemaining,
+      message: `You can change your phone number again in ${daysRemaining} days`
+    };
+  }
+
+  return { canChange: true };
+};
+
+module.exports = {
+  validatePhoneNumber,
+  canChangePhone
+};

--- a/fraudwallet/frontend/src/app/signup/page.tsx
+++ b/fraudwallet/frontend/src/app/signup/page.tsx
@@ -6,7 +6,7 @@ import { useState } from "react"
 import { useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
-import { Wallet, Mail, Lock, User, Eye, EyeOff } from "lucide-react"
+import { Wallet, Mail, Lock, User, Eye, EyeOff, Phone } from "lucide-react"
 import Link from "next/link"
 
 export default function SignupPage() {
@@ -18,6 +18,7 @@ export default function SignupPage() {
   const [formData, setFormData] = useState({
     fullName: "",
     email: "",
+    phoneNumber: "",
     password: "",
     confirmPassword: "",
   })
@@ -25,6 +26,13 @@ export default function SignupPage() {
   const handleSignup = async (e: React.FormEvent) => {
     e.preventDefault()
     setError("")
+
+    // Validate phone number format
+    const phoneRegex = /^\+60\d{10,11}$/
+    if (!phoneRegex.test(formData.phoneNumber.replace(/[\s-]/g, ''))) {
+      setError("Phone number must be in format +60XXXXXXXXXX (10-11 digits)")
+      return
+    }
 
     // Check if passwords match
     if (formData.password !== formData.confirmPassword) {
@@ -50,6 +58,7 @@ export default function SignupPage() {
         body: JSON.stringify({
           fullName: formData.fullName,
           email: formData.email,
+          phoneNumber: formData.phoneNumber,
           password: formData.password,
         }),
       })
@@ -142,6 +151,25 @@ export default function SignupPage() {
                       required
                     />
                   </div>
+                </div>
+
+                <div className="space-y-2">
+                  <label htmlFor="phoneNumber" className="text-sm font-medium">
+                    Phone Number
+                  </label>
+                  <div className="relative">
+                    <Phone className="absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-muted-foreground" />
+                    <Input
+                      id="phoneNumber"
+                      type="tel"
+                      placeholder="+60123456789"
+                      value={formData.phoneNumber}
+                      onChange={(e) => handleChange("phoneNumber", e.target.value)}
+                      className="pl-10"
+                      required
+                    />
+                  </div>
+                  <p className="text-xs text-muted-foreground">Format: +60 followed by 10-11 digits</p>
                 </div>
 
                 <div className="space-y-2">


### PR DESCRIPTION
Backend changes:
- Add phone_number and phone_last_changed fields to database
- Create validation utility for Malaysian phone numbers (+60, 10-11 digits)
- Update signup API to require and validate phone number
- Add PUT /api/user/phone endpoint to change phone number
- Implement 90-day restriction on phone number changes
- Prevent duplicate phone numbers across accounts

Frontend changes:
- Add phone number field to signup page with format validation
- Display current phone number in Account Settings
- Add "Change Phone Number" section with password confirmation
- Show 90-day restriction notice
- Format helper text: +60 followed by 10-11 digits

Security:
- Phone number validation on both frontend and backend
- Password verification required for phone changes
- Unique phone number constraint
- Change frequency limit prevents fraud