### PR TITLE
Fix phone number validation to store digits only

### DIFF
--- a/fraudwallet/backend/src/validation.js
+++ b/fraudwallet/backend/src/validation.js
@@ -2,35 +2,33 @@
 
 /**
  * Validate Malaysian phone number
- * Format: +60 followed by 10-11 digits
- * Examples: +60123456789, +601234567890
+ * Format: 60 followed by 9-10 digits (11-12 digits total)
+ * Examples: 60123456789, 601234567890
+ * Note: User only inputs digits, UI displays +60 prefix
  */
 const validatePhoneNumber = (phone) => {
-  // Remove spaces and dashes
-  const cleanPhone = phone.replace(/[\s-]/g, '');
+  // Remove spaces, dashes, and the "+" symbol
+  let cleanPhone = phone.replace(/[\s\-\+]/g, '');
 
-  // Check if it starts with +60
-  if (!cleanPhone.startsWith('+60')) {
+  // Check if it starts with 60 (Malaysian country code)
+  if (!cleanPhone.startsWith('60')) {
     return {
       valid: false,
-      message: 'Phone number must start with +60 (Malaysia country code)'
+      message: 'Phone number must be a Malaysian number (60XXXXXXXXX)'
     };
   }
 
-  // Remove +60 and check remaining digits
-  const digits = cleanPhone.substring(3);
-
-  // Check if it's 10-11 digits
-  if (!/^\d{10,11}$/.test(digits)) {
+  // Check if length is 11-12 digits total
+  if (!/^60\d{9,10}$/.test(cleanPhone)) {
     return {
       valid: false,
-      message: 'Phone number must have 10-11 digits after +60'
+      message: 'Phone number must be 11-12 digits (60XXXXXXXXX or 60XXXXXXXXXX)'
     };
   }
 
   return {
     valid: true,
-    formatted: cleanPhone
+    formatted: cleanPhone  // Returns digits only: "60123456789"
   };
 };
 

--- a/fraudwallet/frontend/src/app/signup/page.tsx
+++ b/fraudwallet/frontend/src/app/signup/page.tsx
@@ -27,10 +27,12 @@ export default function SignupPage() {
     e.preventDefault()
     setError("")
 
-    // Validate phone number format
-    const phoneRegex = /^\+60\d{10,11}$/
-    if (!phoneRegex.test(formData.phoneNumber.replace(/[\s-]/g, ''))) {
-      setError("Phone number must be in format +60XXXXXXXXXX (10-11 digits)")
+    // Validate phone number format (user inputs 9-10 digits, we prepend "60")
+    const phoneDigits = formData.phoneNumber.replace(/[\s\-\+]/g, '')
+    const fullPhone = phoneDigits.startsWith('60') ? phoneDigits : `60${phoneDigits}`
+    const phoneRegex = /^60\d{9,10}$/
+    if (!phoneRegex.test(fullPhone)) {
+      setError("Phone number must be 9-10 digits (Malaysian number)")
       return
     }
 
@@ -58,7 +60,7 @@ export default function SignupPage() {
         body: JSON.stringify({
           fullName: formData.fullName,
           email: formData.email,
-          phoneNumber: formData.phoneNumber,
+          phoneNumber: fullPhone,  // Send complete phone with "60" prefix
           password: formData.password,
         }),
       })
@@ -159,17 +161,28 @@ export default function SignupPage() {
                   </label>
                   <div className="relative">
                     <Phone className="absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-muted-foreground" />
+                    <span className="absolute left-10 top-1/2 -translate-y-1/2 text-sm text-muted-foreground">
+                      +60
+                    </span>
                     <Input
                       id="phoneNumber"
                       type="tel"
-                      placeholder="+60123456789"
+                      placeholder="123456789"
                       value={formData.phoneNumber}
-                      onChange={(e) => handleChange("phoneNumber", e.target.value)}
-                      className="pl-10"
+                      onChange={(e) => {
+                        // Remove any non-digit characters and remove "60" prefix if user types it
+                        let value = e.target.value.replace(/\D/g, '')
+                        if (value.startsWith('60')) {
+                          value = value.substring(2)
+                        }
+                        handleChange("phoneNumber", value)
+                      }}
+                      className="pl-16"
                       required
+                      maxLength={10}
                     />
                   </div>
-                  <p className="text-xs text-muted-foreground">Format: +60 followed by 10-11 digits</p>
+                  <p className="text-xs text-muted-foreground">Enter 9-10 digits (Malaysian number)</p>
                 </div>
 
                 <div className="space-y-2">

--- a/fraudwallet/frontend/src/components/profile-tab.tsx
+++ b/fraudwallet/frontend/src/components/profile-tab.tsx
@@ -151,10 +151,12 @@ export function ProfileTab() {
       return
     }
 
-    // Validate phone number format
-    const phoneRegex = /^\+60\d{10,11}$/
-    if (!phoneRegex.test(newPhoneNumber.replace(/[\s-]/g, ''))) {
-      setError("Phone number must be in format +60XXXXXXXXXX (10-11 digits)")
+    // Validate phone number format (user inputs 9-10 digits, we prepend "60")
+    const phoneDigits = newPhoneNumber.replace(/[\s\-\+]/g, '')
+    const fullPhone = phoneDigits.startsWith('60') ? phoneDigits : `60${phoneDigits}`
+    const phoneRegex = /^60\d{9,10}$/
+    if (!phoneRegex.test(fullPhone)) {
+      setError("Phone number must be 9-10 digits (Malaysian number)")
       return
     }
 
@@ -170,7 +172,7 @@ export function ProfileTab() {
           "Authorization": `Bearer ${token}`
         },
         body: JSON.stringify({
-          newPhoneNumber,
+          newPhoneNumber: fullPhone,  // Send complete phone with "60" prefix
           password: phoneChangePassword
         })
       })
@@ -430,7 +432,7 @@ export function ProfileTab() {
               <div className="space-y-4">
                 <h4 className="font-semibold">Change Phone Number</h4>
                 <p className="text-sm text-muted-foreground">
-                  Current: {user?.phoneNumber || "Not set"}
+                  Current: +{user?.phoneNumber || "Not set"}
                 </p>
                 <p className="text-xs text-muted-foreground">
                   Note: You can only change your phone number once every 90 days
@@ -438,12 +440,27 @@ export function ProfileTab() {
 
                 <div>
                   <label className="text-sm font-medium">New Phone Number</label>
-                  <Input
-                    type="tel"
-                    value={newPhoneNumber}
-                    onChange={(e) => setNewPhoneNumber(e.target.value)}
-                    placeholder="+60123456789"
-                  />
+                  <div className="relative">
+                    <span className="absolute left-3 top-1/2 -translate-y-1/2 text-sm text-muted-foreground">
+                      +60
+                    </span>
+                    <Input
+                      type="tel"
+                      value={newPhoneNumber}
+                      onChange={(e) => {
+                        // Remove any non-digit characters and remove "60" prefix if user types it
+                        let value = e.target.value.replace(/\D/g, '')
+                        if (value.startsWith('60')) {
+                          value = value.substring(2)
+                        }
+                        setNewPhoneNumber(value)
+                      }}
+                      placeholder="123456789"
+                      className="pl-12"
+                      maxLength={10}
+                    />
+                  </div>
+                  <p className="text-xs text-muted-foreground mt-1">Enter 9-10 digits (Malaysian number)</p>
                 </div>
 
                 <div>


### PR DESCRIPTION
Updated phone number handling to match requirements:
- User sees +60 prefix but only enters 9-10 digits
- Auto-removes +60 if user types it
- Database stores only digits (60123456789 or 601234567890)
- Length validation: 11-12 digits total