### PR TITLE
Add recipient lookup feature for payments

### DIFF
--- a/fraudwallet/backend/src/server.js
+++ b/fraudwallet/backend/src/server.js
@@ -48,6 +48,9 @@ app.post('/api/user/2fa/toggle', verifyToken, user.toggle2FA);
 app.put('/api/user/2fa/method', verifyToken, user.update2FAMethod);
 app.post('/api/user/2fa/test', verifyToken, user.send2FATest);
 
+// Payment routes (protected)
+app.post('/api/payment/lookup-recipient', verifyToken, user.lookupRecipient);
+
 // Start the server
 const PORT = process.env.PORT || 8080;
 app.listen(PORT, () => {


### PR DESCRIPTION
Backend changes:
- Add lookupRecipient() function to search users by phone/email/Account ID
- Support searching by 12-digit Account ID (exact match)
- Support searching by email address
- Support searching by phone number (with normalization)
- Validate that users cannot send money to themselves
- Only return active accounts
- Add /api/payment/lookup-recipient endpoint

Frontend changes:
- Add "Lookup" button next to recipient input field
- Add recipient details display card showing:
  - Full name
  - Account ID
  - Email address
  - Phone number
- Add loading state while looking up recipient
- Add error handling and display
- Clear recipient data when input changes
- Support Enter key to trigger lookup
- Add visual feedback with colored card for found recipient

Users can now verify recipient details before sending money by entering phone number, email, or Account ID and clicking Lookup.