### PR TITLE
Fix SQL syntax error in SplitPay participant validation

### DIFF
--- a/fraudwallet/backend/src/splitpay.js
+++ b/fraudwallet/backend/src/splitpay.js
@@ -53,7 +53,7 @@ const createSplitPayment = async (req, res) => {
 
     for (const participantId of participants) {
       // Validate participant exists
-      const participantUser = db.prepare('SELECT id FROM users WHERE id = ? AND account_status = "active"').get(participantId);
+      const participantUser = db.prepare("SELECT id FROM users WHERE id = ? AND account_status = 'active'").get(participantId);
 
       if (!participantUser) {
         // Rollback - delete the split payment


### PR DESCRIPTION
Change double quotes to single quotes for string literal 'active' in account_status comparison. SQLite requires single quotes for string literals and double quotes for identifiers.