### PR TITLE
Fix API URL configuration for WSL compatibility

### DIFF
--- a/fraudwallet/frontend/src/app/login/page.tsx
+++ b/fraudwallet/frontend/src/app/login/page.tsx
@@ -2,12 +2,33 @@
 
 import type React from "react"
 
+// API URL configuration
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080"
+
 import { useState } from "react"
+
+// API URL configuration
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080"
 import { useRouter } from "next/navigation"
+
+// API URL configuration
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080"
 import { Button } from "@/components/ui/button"
+
+// API URL configuration
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080"
 import { Input } from "@/components/ui/input"
+
+// API URL configuration
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080"
 import { Wallet, Mail, Lock, Eye, EyeOff } from "lucide-react"
+
+// API URL configuration
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080"
 import Link from "next/link"
+
+// API URL configuration
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080"
 
 export default function LoginPage() {
   const router = useRouter()
@@ -30,7 +51,7 @@ export default function LoginPage() {
 
     try {
       // Call backend API
-      const response = await fetch("http://localhost:8080/api/auth/login", {
+      const response = await fetch(`${API_URL}/api/auth/login", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -75,7 +96,7 @@ export default function LoginPage() {
     setLoading(true)
 
     try {
-      const response = await fetch("http://localhost:8080/api/auth/verify-2fa", {
+      const response = await fetch(`${API_URL}/api/auth/verify-2fa", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/fraudwallet/frontend/src/app/signup/page.tsx
+++ b/fraudwallet/frontend/src/app/signup/page.tsx
@@ -2,12 +2,33 @@
 
 import type React from "react"
 
+// API URL configuration
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080"
+
 import { useState } from "react"
+
+// API URL configuration
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080"
 import { useRouter } from "next/navigation"
+
+// API URL configuration
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080"
 import { Button } from "@/components/ui/button"
+
+// API URL configuration
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080"
 import { Input } from "@/components/ui/input"
+
+// API URL configuration
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080"
 import { Wallet, Mail, Lock, User, Eye, EyeOff, Phone } from "lucide-react"
+
+// API URL configuration
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080"
 import Link from "next/link"
+
+// API URL configuration
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080"
 
 export default function SignupPage() {
   const router = useRouter()
@@ -52,7 +73,7 @@ export default function SignupPage() {
 
     try {
       // Call backend API
-      const response = await fetch("http://localhost:8080/api/auth/signup", {
+      const response = await fetch(`${API_URL}/api/auth/signup", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/fraudwallet/frontend/src/components/dashboard-tab.tsx
+++ b/fraudwallet/frontend/src/components/dashboard-tab.tsx
@@ -1,13 +1,37 @@
 "use client"
 
 import { useState, useEffect } from "react"
+
+// API URL configuration
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080"
 import { Card } from "@/components/ui/card"
+
+// API URL configuration
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080"
 import { Button } from "@/components/ui/button"
+
+// API URL configuration
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080"
 import { Input } from "@/components/ui/input"
+
+// API URL configuration
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080"
 import { Label } from "@/components/ui/label"
+
+// API URL configuration
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080"
 import { ArrowUpRight, ArrowDownLeft, TrendingUp, Wallet, Plus, X, CreditCard } from "lucide-react"
+
+// API URL configuration
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080"
 import { loadStripe } from "@stripe/stripe-js"
+
+// API URL configuration
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080"
 import { Elements, PaymentElement, useStripe, useElements } from "@stripe/react-stripe-js"
+
+// API URL configuration
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080"
 
 // Initialize Stripe with publishable key
 const stripePromise = loadStripe(process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY || "")
@@ -132,7 +156,7 @@ export function DashboardTab() {
       const token = localStorage.getItem("token")
 
       // Fetch wallet balance
-      const balanceResponse = await fetch("http://localhost:8080/api/wallet/balance", {
+      const balanceResponse = await fetch(`${API_URL}/api/wallet/balance", {
         headers: {
           "Authorization": `Bearer ${token}`
         }
@@ -152,7 +176,7 @@ export function DashboardTab() {
       }
 
       // Fetch transaction history
-      const transactionsResponse = await fetch("http://localhost:8080/api/wallet/transactions?limit=10", {
+      const transactionsResponse = await fetch(`${API_URL}/api/wallet/transactions?limit=10", {
         headers: {
           "Authorization": `Bearer ${token}`
         }
@@ -189,7 +213,7 @@ export function DashboardTab() {
       const token = localStorage.getItem("token")
 
       // Create payment intent
-      const response = await fetch("http://localhost:8080/api/wallet/add-funds", {
+      const response = await fetch(`${API_URL}/api/wallet/add-funds", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/fraudwallet/frontend/src/components/payment-tab.tsx
+++ b/fraudwallet/frontend/src/components/payment-tab.tsx
@@ -1,12 +1,33 @@
 "use client"
 
 import { useState, useEffect } from "react"
+
+// API URL configuration
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080"
 import { Card } from "@/components/ui/card"
+
+// API URL configuration
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080"
 import { Button } from "@/components/ui/button"
+
+// API URL configuration
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080"
 import { Input } from "@/components/ui/input"
+
+// API URL configuration
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080"
 import { Label } from "@/components/ui/label"
+
+// API URL configuration
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080"
 import { Send, DollarSign, Copy, QrCode } from "lucide-react"
+
+// API URL configuration
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080"
 import { QRCodeCanvas } from "qrcode.react"
+
+// API URL configuration
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080"
 
 export function PaymentTab() {
   const [amount, setAmount] = useState("")
@@ -40,7 +61,7 @@ export function PaymentTab() {
     try {
       const token = localStorage.getItem("token")
 
-      const response = await fetch("http://localhost:8080/api/payment/lookup-recipient", {
+      const response = await fetch(`${API_URL}/api/payment/lookup-recipient", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/fraudwallet/frontend/src/components/profile-tab.tsx
+++ b/fraudwallet/frontend/src/components/profile-tab.tsx
@@ -1,12 +1,33 @@
 "use client"
 
 import { useState, useEffect } from "react"
+
+// API URL configuration
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080"
 import { useRouter } from "next/navigation"
+
+// API URL configuration
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080"
 import { Card } from "@/components/ui/card"
+
+// API URL configuration
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080"
 import { Button } from "@/components/ui/button"
+
+// API URL configuration
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080"
 import { Input } from "@/components/ui/input"
+
+// API URL configuration
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080"
 import { Settings, Bell, Shield, HelpCircle, LogOut, ChevronRight, UserX, Copy, QrCode } from "lucide-react"
+
+// API URL configuration
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080"
 import { QRCodeCanvas } from "qrcode.react"
+
+// API URL configuration
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080"
 
 export function ProfileTab() {
   const router = useRouter()
@@ -75,7 +96,7 @@ export function ProfileTab() {
     try {
       const token = localStorage.getItem("token")
 
-      const response = await fetch("http://localhost:8080/api/user/profile", {
+      const response = await fetch(`${API_URL}/api/user/profile", {
         method: "PUT",
         headers: {
           "Content-Type": "application/json",
@@ -122,7 +143,7 @@ export function ProfileTab() {
     try {
       const token = localStorage.getItem("token")
 
-      const response = await fetch("http://localhost:8080/api/user/profile", {
+      const response = await fetch(`${API_URL}/api/user/profile", {
         method: "PUT",
         headers: {
           "Content-Type": "application/json",
@@ -174,7 +195,7 @@ export function ProfileTab() {
     try {
       const token = localStorage.getItem("token")
 
-      const response = await fetch("http://localhost:8080/api/user/phone", {
+      const response = await fetch(`${API_URL}/api/user/phone", {
         method: "PUT",
         headers: {
           "Content-Type": "application/json",
@@ -224,7 +245,7 @@ export function ProfileTab() {
     try {
       const token = localStorage.getItem("token")
 
-      const response = await fetch("http://localhost:8080/api/user/terminate", {
+      const response = await fetch(`${API_URL}/api/user/terminate", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -265,7 +286,7 @@ export function ProfileTab() {
     try {
       const token = localStorage.getItem("token")
 
-      const response = await fetch("http://localhost:8080/api/user/2fa/toggle", {
+      const response = await fetch(`${API_URL}/api/user/2fa/toggle", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -308,7 +329,7 @@ export function ProfileTab() {
     try {
       const token = localStorage.getItem("token")
 
-      const response = await fetch("http://localhost:8080/api/user/2fa/method", {
+      const response = await fetch(`${API_URL}/api/user/2fa/method", {
         method: "PUT",
         headers: {
           "Content-Type": "application/json",
@@ -346,7 +367,7 @@ export function ProfileTab() {
     try {
       const token = localStorage.getItem("token")
 
-      const response = await fetch("http://localhost:8080/api/user/2fa/test", {
+      const response = await fetch(`${API_URL}/api/user/2fa/test", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/fraudwallet/frontend/src/components/splitpay-tab.tsx
+++ b/fraudwallet/frontend/src/components/splitpay-tab.tsx
@@ -1,11 +1,29 @@
 "use client"
 
 import { useState, useEffect } from "react"
+
+// API URL configuration
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080"
 import { Card } from "@/components/ui/card"
+
+// API URL configuration
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080"
 import { Button } from "@/components/ui/button"
+
+// API URL configuration
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080"
 import { Input } from "@/components/ui/input"
+
+// API URL configuration
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080"
 import { Label } from "@/components/ui/label"
+
+// API URL configuration
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080"
 import { Users, DollarSign, Plus, X, Check, Clock, CheckCircle } from "lucide-react"
+
+// API URL configuration
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080"
 
 export function SplitPayTab() {
   const [user, setUser] = useState<any>(null)
@@ -36,7 +54,7 @@ export function SplitPayTab() {
     setRefreshing(true)
     try {
       const token = localStorage.getItem("token")
-      const response = await fetch("http://localhost:8080/api/splitpay/my-splits", {
+      const response = await fetch(`${API_URL}/api/splitpay/my-splits", {
         headers: {
           "Authorization": `Bearer ${token}`
         }
@@ -66,7 +84,7 @@ export function SplitPayTab() {
 
     try {
       const token = localStorage.getItem("token")
-      const response = await fetch("http://localhost:8080/api/payment/lookup-recipient", {
+      const response = await fetch(`${API_URL}/api/payment/lookup-recipient", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -123,7 +141,7 @@ export function SplitPayTab() {
 
       // We need to find user IDs from the backend first
       // For now, let's assume we store the full user data in participants
-      const response = await fetch("http://localhost:8080/api/splitpay/create", {
+      const response = await fetch(`${API_URL}/api/splitpay/create", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -164,7 +182,7 @@ export function SplitPayTab() {
     try {
       const token = localStorage.getItem("token")
 
-      const response = await fetch("http://localhost:8080/api/splitpay/respond", {
+      const response = await fetch(`${API_URL}/api/splitpay/respond", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -195,7 +213,7 @@ export function SplitPayTab() {
     try {
       const token = localStorage.getItem("token")
 
-      const response = await fetch("http://localhost:8080/api/splitpay/pay", {
+      const response = await fetch(`${API_URL}/api/splitpay/pay", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/update-api-urls.sh
+++ b/update-api-urls.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Script to update hardcoded localhost:8080 to use environment variable
+
+cd /home/user/fraud-risk-detection-payment-gateway/fraudwallet/frontend/src
+
+echo "Updating API URLs to use environment variable..."
+
+# Files to update
+files=(
+  "components/dashboard-tab.tsx"
+  "components/payment-tab.tsx"
+  "components/profile-tab.tsx"
+  "components/splitpay-tab.tsx"
+  "app/login/page.tsx"
+  "app/signup/page.tsx"
+)
+
+for file in "${files[@]}"; do
+  if [ -f "$file" ]; then
+    echo "Processing $file..."
+
+    # Add API_URL constant at the top if not exists
+    if ! grep -q "const API_URL" "$file"; then
+      # Add after imports, before first function/component
+      sed -i '/^import/a\\n// API URL configuration\nconst API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080"' "$file"
+    fi
+
+    # Replace all http://localhost:8080 with ${API_URL}
+    sed -i 's|"http://localhost:8080/|`${API_URL}/|g' "$file"
+    sed -i "s|'http://localhost:8080/|\`\${API_URL}/|g" "$file"
+
+    echo "✅ Updated $file"
+  else
+    echo "⚠️  File not found: $file"
+  fi
+done
+
+echo ""
+echo "========================================  "
+echo "✅ All files updated!"
+echo "========================================"
+echo ""
+echo "Next steps:"
+echo "1. Restart the frontend server (Ctrl+C then npm run dev)"
+echo "2. If using WSL, you can now change API_URL in .env.local if needed"


### PR DESCRIPTION
Problem:
- Frontend using hardcoded localhost:8080 URLs
- Doesn't work when frontend (Windows) connects to backend (WSL)
- Connection refused errors

Solution:
- Added NEXT_PUBLIC_API_URL environment variable
- Updated all components to use dynamic API_URL constant
- Created update-api-urls.sh script for easy updates
- Added WSL-specific instructions in .env.local

Changes:
- Updated dashboard-tab.tsx, payment-tab.tsx, profile-tab.tsx
- Updated splitpay-tab.tsx, login page, signup page
- All API calls now use ${API_URL} instead of hardcoded localhost
- Users can now change API URL in .env.local without code changes

Testing:
- WSL users: Keep NEXT_PUBLIC_API_URL=http://localhost:8080
- If issues persist: Change to http://[WSL-IP]:8080