### PR TITLE
Add authentication protection to prevent unauthorized access

### DIFF
--- a/fraudwallet/frontend/src/app/page.tsx
+++ b/fraudwallet/frontend/src/app/page.tsx
@@ -6,9 +6,29 @@ import { PaymentTab } from "@/components/payment-tab"
 import { SplitPayTab } from "@/components/splitpay-tab"
 import { ProfileTab } from "@/components/profile-tab"
 import { Home, Send, Users, User } from "lucide-react"
+import { useAuth } from "@/hooks/useAuth"
 
 export default function WalletApp() {
   const [activeTab, setActiveTab] = useState<"dashboard" | "payment" | "splitpay" | "profile">("dashboard")
+  const { isAuthenticated, isLoading } = useAuth()
+
+  // Show loading screen while checking authentication
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-muted">
+        <div className="text-center">
+          <div className="mb-4 h-12 w-12 animate-spin rounded-full border-4 border-primary border-t-transparent mx-auto" />
+          <p className="text-muted-foreground">Loading...</p>
+        </div>
+      </div>
+    )
+  }
+
+  // If not authenticated, useAuth hook will redirect to login
+  // This is just a safeguard
+  if (!isAuthenticated) {
+    return null
+  }
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-muted p-4">

--- a/fraudwallet/frontend/src/hooks/useAuth.ts
+++ b/fraudwallet/frontend/src/hooks/useAuth.ts
@@ -1,0 +1,57 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { useRouter } from "next/navigation"
+
+/**
+ * Custom hook for authentication
+ * Checks if user is logged in and redirects if not
+ */
+export function useAuth() {
+  const router = useRouter()
+  const [isAuthenticated, setIsAuthenticated] = useState(false)
+  const [isLoading, setIsLoading] = useState(true)
+  const [user, setUser] = useState<any>(null)
+
+  useEffect(() => {
+    // Check if user is logged in
+    const token = localStorage.getItem("token")
+    const storedUser = localStorage.getItem("user")
+
+    if (!token || !storedUser) {
+      // Not logged in - redirect to login
+      router.push("/login")
+      setIsLoading(false)
+      return
+    }
+
+    try {
+      const userData = JSON.parse(storedUser)
+      setUser(userData)
+      setIsAuthenticated(true)
+    } catch (error) {
+      console.error("Error parsing user data:", error)
+      // Invalid data - clear and redirect to login
+      localStorage.removeItem("token")
+      localStorage.removeItem("user")
+      router.push("/login")
+    } finally {
+      setIsLoading(false)
+    }
+  }, [router])
+
+  const logout = () => {
+    localStorage.removeItem("token")
+    localStorage.removeItem("user")
+    setIsAuthenticated(false)
+    setUser(null)
+    router.push("/login")
+  }
+
+  return {
+    isAuthenticated,
+    isLoading,
+    user,
+    logout
+  }
+}


### PR DESCRIPTION
Implemented client-side route protection to ensure users must be logged in to access the app.

Frontend changes:
- Created useAuth() custom hook for session management
  - Checks for valid token and user data in localStorage
  - Redirects to /login if not authenticated
  - Provides logout functionality
  - Returns loading state during auth check
- Updated main app page to use authentication protection
  - Shows loading spinner while checking auth
  - Redirects unauthenticated users to login
  - Prevents accessing app without valid session

Features:
- Automatic redirect to login if no session found
- Session validation on app load
- Loading state during authentication check
- Clean logout flow clearing all session data

This prevents users from accessing the app without logging in first.