### PR TITLE
Add strict amount validation and enforce 2-decimal rounding

### DIFF
--- a/fraudwallet/frontend/src/components/payment-tab.tsx
+++ b/fraudwallet/frontend/src/components/payment-tab.tsx
@@ -7,6 +7,7 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Send, DollarSign, Copy, QrCode } from "lucide-react"
 import { QRCodeCanvas } from "qrcode.react"
+import { validateAmount } from "@/utils/amountValidation"
 
 export function PaymentTab() {
   const [amount, setAmount] = useState("")
@@ -76,8 +77,10 @@ export function PaymentTab() {
     setSendSuccess(false)
 
     // Validate amount
-    if (!amount || parseFloat(amount) <= 0) {
-      setSendError("Please enter a valid amount")
+    const validation = validateAmount(amount)
+
+    if (!validation.isValid) {
+      setSendError(validation.error || "Invalid amount")
       return
     }
 
@@ -86,6 +89,9 @@ export function PaymentTab() {
       setSendError("Please lookup and confirm the recipient first")
       return
     }
+
+    // Use the validated and rounded amount
+    const validatedAmount = validation.value
 
     setSendLoading(true)
 
@@ -100,7 +106,7 @@ export function PaymentTab() {
         },
         body: JSON.stringify({
           recipientId: recipientData.id,
-          amount: parseFloat(amount),
+          amount: validatedAmount,
           note: note || undefined
         })
       })
@@ -179,7 +185,7 @@ export function PaymentTab() {
       {/* Amount Input */}
       <Card className="p-6">
         <Label htmlFor="amount" className="text-sm text-muted-foreground">
-          Amount
+          Amount (Max: RM 999,999.99)
         </Label>
         <div className="mt-2 flex items-center gap-2">
           <DollarSign className="h-8 w-8 text-muted-foreground" />
@@ -189,6 +195,9 @@ export function PaymentTab() {
             placeholder="0.00"
             value={amount}
             onChange={(e) => setAmount(e.target.value)}
+            min="0.01"
+            max="999999.99"
+            step="0.01"
             className="w-full border-none bg-transparent text-4xl font-bold outline-none placeholder:text-muted-foreground/50"
           />
         </div>

--- a/fraudwallet/frontend/src/utils/amountValidation.ts
+++ b/fraudwallet/frontend/src/utils/amountValidation.ts
@@ -1,0 +1,76 @@
+/**
+ * Validates and formats money amounts for payments
+ */
+
+export const AMOUNT_LIMITS = {
+  MIN: 0.01,
+  MAX: 999999.99,
+  MIN_TOPUP: 10.00
+}
+
+/**
+ * Validates if an amount is within acceptable range
+ * @param amount - The amount to validate
+ * @param options - Validation options
+ * @returns Object with isValid flag and error message
+ */
+export function validateAmount(
+  amount: number | string,
+  options: { minTopup?: boolean } = {}
+): { isValid: boolean; error: string | null; value: number } {
+  // Convert to number
+  const numAmount = typeof amount === 'string' ? parseFloat(amount) : amount
+
+  // Check if valid number
+  if (isNaN(numAmount)) {
+    return { isValid: false, error: 'Please enter a valid amount', value: 0 }
+  }
+
+  // Check if positive
+  if (numAmount <= 0) {
+    return { isValid: false, error: 'Amount must be greater than zero', value: 0 }
+  }
+
+  // Check minimum for top-up
+  if (options.minTopup && numAmount < AMOUNT_LIMITS.MIN_TOPUP) {
+    return {
+      isValid: false,
+      error: `Minimum top-up amount is RM ${AMOUNT_LIMITS.MIN_TOPUP.toFixed(2)}`,
+      value: 0
+    }
+  }
+
+  // Check maximum
+  if (numAmount > AMOUNT_LIMITS.MAX) {
+    return {
+      isValid: false,
+      error: `Maximum amount is RM ${AMOUNT_LIMITS.MAX.toLocaleString('en-MY', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`,
+      value: 0
+    }
+  }
+
+  // Round to 2 decimal places
+  const roundedAmount = Math.round(numAmount * 100) / 100
+
+  return { isValid: true, error: null, value: roundedAmount }
+}
+
+/**
+ * Formats amount to 2 decimal places
+ * @param amount - The amount to format
+ * @returns Formatted amount rounded to 2 decimals
+ */
+export function formatAmount(amount: number | string): number {
+  const numAmount = typeof amount === 'string' ? parseFloat(amount) : amount
+  if (isNaN(numAmount)) return 0
+  return Math.round(numAmount * 100) / 100
+}
+
+/**
+ * Formats amount for display with MYR currency
+ * @param amount - The amount to format
+ * @returns Formatted string like "RM 123.45"
+ */
+export function formatCurrency(amount: number): string {
+  return `RM ${amount.toFixed(2)}`
+}


### PR DESCRIPTION
Implemented comprehensive amount validation for all payment operations to ensure:
- Only positive numbers accepted
- Maximum amount capped at RM 999,999.99
- All amounts rounded to exactly 2 decimal places (cents)
- Prevents cases like RM 123,456.999999999

Frontend changes:
- Created amountValidation.ts utility with:
  - validateAmount() function for input validation
  - formatAmount() for 2-decimal rounding
  - AMOUNT_LIMITS constants (min: 0.01, max: 999,999.99)
- Updated dashboard-tab.tsx (add funds):
  - Integrated validation before creating payment intent
  - Updated UI to show min/max limits
  - Changed input step to 0.01 for precise cents
- Updated payment-tab.tsx (user transfers):
  - Integrated validation before sending money
  - Added max amount display in UI
  - Enforced 2-decimal precision

Backend changes:
- Added validateAmount() function in wallet.js:
  - Validates and rounds amounts server-side
  - Enforces same limits as frontend
  - Returns validated value rounded to 2 decimals
- Updated createPaymentIntent():
  - Validates amount before creating Stripe intent
  - Min top-up: RM 10.00
  - Uses validated/rounded amount
- Updated sendMoney():
  - Validates transfer amount
  - Prevents decimal overflow in transactions
  - Ensures consistent 2-decimal storage

All monetary values now guaranteed to be:
✓ Positive numbers only
✓ Maximum RM 999,999.99
✓ Exactly 2 decimal places (no .999999999)
✓ Validated both client and server-side