### PR TITLE
Add split payment cancellation with automatic refunds

### DIFF
--- a/fraudwallet/backend/src/server.js
+++ b/fraudwallet/backend/src/server.js
@@ -63,6 +63,7 @@ app.post('/api/splitpay/create', verifyToken, splitpay.createSplitPayment);
 app.get('/api/splitpay/my-splits', verifyToken, splitpay.getMySplitPayments);
 app.post('/api/splitpay/respond', verifyToken, splitpay.respondToSplitPayment);
 app.post('/api/splitpay/pay', verifyToken, splitpay.payMyShare);
+app.post('/api/splitpay/cancel', verifyToken, splitpay.cancelSplitPayment);
 
 // Wallet routes (protected)
 app.get('/api/wallet/balance', verifyToken, wallet.getWalletBalance);


### PR DESCRIPTION
Implemented complete split payment cancellation functionality allowing creators to cancel splits at any time, with automatic refunds for participants who already paid.

Backend changes:
- Updated payMyShare() to perform actual money transfers:
  - Deducts amount from participant's wallet
  - Credits creator's wallet
  - Creates transaction records for both parties
  - Validates sufficient balance before payment
  - Checks if split is cancelled before allowing payment
- Added cancelSplitPayment() function:
  - Only creator can cancel
  - Cannot cancel completed splits
  - Calculates total refund needed
  - Validates creator has sufficient balance for refunds
  - Performs atomic transaction for all refunds
  - Creates refund transaction records
  - Resets paid status for all participants
  - Marks split as cancelled
- Updated getMySplitPayments() to include creator_id
- Added POST /api/splitpay/cancel route

Frontend changes:
- Added handleCancelSplit() function with confirmation dialog
- Added cancel button for creators (visible on pending/active splits)
- Shows refund count and amount after cancellation
- Button only visible to split creator
- Automatically refreshes split list after cancellation

Features:
- Creator can cancel split at any time (pending or active)
- Automatic refund to all participants who paid
- Creator must have sufficient balance to refund
- Cannot cancel completed splits
- Atomic transactions ensure data consistency
- Full transaction history for refunds
- Prevents payment to cancelled splits

Example:
- 3 people in split, 2 already paid RM50 each
- Creator cancels → Creator's wallet: -RM100, Participants: +RM50 each
- All transactions recorded in database