### PR TITLE
Fix 2FA disable flow with proper OTP validation

### DIFF
--- a/fraudwallet/backend/src/server.js
+++ b/fraudwallet/backend/src/server.js
@@ -51,6 +51,7 @@ app.post('/api/user/terminate', verifyToken, user.terminateAccount);
 
 // 2FA management routes (protected)
 app.post('/api/user/2fa/toggle', verifyToken, user.toggle2FA);
+app.post('/api/user/2fa/send-disable-code', verifyToken, user.sendDisableCode);
 app.put('/api/user/2fa/method', verifyToken, user.update2FAMethod);
 app.post('/api/user/2fa/test', verifyToken, user.send2FATest);
 


### PR DESCRIPTION
Security Issue Fixed:
- Previously users could bypass 2FA disable by entering random values
- Now implements proper OTP verification before disabling 2FA

Changes:
1. Frontend (profile-tab.tsx):
   - Added two-step disable flow: Step 1: Enter password and send verification code Step 2: Enter received code and disable 2FA
   - Added "Send Verification Code" button
   - Added "Resend Code" functionality
   - Better UX with step-by-step guidance

2. Backend (user.js):
   - Added sendDisableCode endpoint to send OTP after password verification
   - Updated toggle2FA to properly validate OTP using verifyCode function
   - Uses 'disable_2fa' purpose to prevent code reuse from other flows
   - Validates both password AND OTP before allowing 2FA disable

3. Backend (server.js):
   - Added route: POST /api/user/2fa/send-disable-code

Security Flow:
1. User enters password → Backend verifies → Sends OTP to email/phone
2. User enters OTP → Backend validates OTP → Disables 2FA