### PR TITLE
Fix 2FA disable email format - include user name parameter

### DIFF
--- a/fraudwallet/backend/src/user.js
+++ b/fraudwallet/backend/src/user.js
@@ -461,7 +461,7 @@ const sendDisableCode = async (req, res) => {
 
     // Send code based on user's 2FA method
     if (user.twofa_method === 'email') {
-      await sendEmailCode(user.email, code);
+      await sendEmailCode(user.email, user.full_name, code);
     } else if (user.twofa_method === 'phone') {
       await sendSMSCode(user.phone_number, code);
     }


### PR DESCRIPTION
Issue: Email showed code as name and "undefined" as verification code
Fix: Pass user.full_name as second parameter to sendEmailCode()

Now email will correctly show:
- Hi [User Name],
- Your verification code is: [123456]