### PR TITLE
Fix Docker shared module paths

### DIFF
--- a/fraudwallet/services/auth-service/Dockerfile
+++ b/fraudwallet/services/auth-service/Dockerfile
@@ -3,7 +3,7 @@ FROM node:20-alpine
 WORKDIR /app
 
 # Copy shared dependencies first
-COPY services/shared /app/shared
+COPY services/shared /shared
 
 # Copy service package files
 COPY services/auth-service/package*.json ./

--- a/fraudwallet/services/auth-service/Dockerfile.dev
+++ b/fraudwallet/services/auth-service/Dockerfile.dev
@@ -2,14 +2,14 @@ FROM node:20-alpine
 
 WORKDIR /app
 
-# Copy shared dependencies
-COPY services/shared /app/shared
-
 # Copy package files
 COPY services/auth-service/package*.json ./
 
 # Install dependencies including dev dependencies
 RUN npm install
+
+# Copy shared dependencies to parent directory (so ../../shared works)
+COPY services/shared /shared
 
 # Copy source code
 COPY services/auth-service/src ./src

--- a/fraudwallet/services/fraud-detection-service/Dockerfile
+++ b/fraudwallet/services/fraud-detection-service/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:20-alpine
 WORKDIR /app
-COPY services/shared /app/shared
+COPY services/shared /shared
 COPY services/fraud-detection-service/package*.json ./
 RUN npm ci --only=production
 COPY services/fraud-detection-service/src ./src

--- a/fraudwallet/services/fraud-detection-service/Dockerfile.dev
+++ b/fraudwallet/services/fraud-detection-service/Dockerfile.dev
@@ -1,6 +1,6 @@
 FROM node:20-alpine
 WORKDIR /app
-COPY services/shared /app/shared
+COPY services/shared /shared
 COPY services/fraud-detection-service/package*.json ./
 RUN npm install
 COPY services/fraud-detection-service/src ./src

--- a/fraudwallet/services/splitpay-service/Dockerfile
+++ b/fraudwallet/services/splitpay-service/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:20-alpine
 WORKDIR /app
-COPY services/shared /app/shared
+COPY services/shared /shared
 COPY services/splitpay-service/package*.json ./
 RUN npm ci --only=production
 COPY services/splitpay-service/src ./src

--- a/fraudwallet/services/splitpay-service/Dockerfile.dev
+++ b/fraudwallet/services/splitpay-service/Dockerfile.dev
@@ -1,6 +1,6 @@
 FROM node:20-alpine
 WORKDIR /app
-COPY services/shared /app/shared
+COPY services/shared /shared
 COPY services/splitpay-service/package*.json ./
 RUN npm install
 COPY services/splitpay-service/src ./src

--- a/fraudwallet/services/user-service/Dockerfile
+++ b/fraudwallet/services/user-service/Dockerfile
@@ -3,7 +3,7 @@ FROM node:20-alpine
 WORKDIR /app
 
 # Copy shared dependencies
-COPY services/shared /app/shared
+COPY services/shared /shared
 
 # Copy package files
 COPY services/user-service/package*.json ./

--- a/fraudwallet/services/user-service/Dockerfile.dev
+++ b/fraudwallet/services/user-service/Dockerfile.dev
@@ -3,7 +3,7 @@ FROM node:20-alpine
 WORKDIR /app
 
 # Copy shared dependencies
-COPY services/shared /app/shared
+COPY services/shared /shared
 
 # Copy package files
 COPY services/user-service/package*.json ./

--- a/fraudwallet/services/wallet-service/Dockerfile
+++ b/fraudwallet/services/wallet-service/Dockerfile
@@ -3,7 +3,7 @@ FROM node:20-alpine
 WORKDIR /app
 
 # Copy shared dependencies
-COPY services/shared /app/shared
+COPY services/shared /shared
 
 # Copy package files
 COPY services/wallet-service/package*.json ./

--- a/fraudwallet/services/wallet-service/Dockerfile.dev
+++ b/fraudwallet/services/wallet-service/Dockerfile.dev
@@ -3,7 +3,7 @@ FROM node:20-alpine
 WORKDIR /app
 
 # Copy shared dependencies
-COPY services/shared /app/shared
+COPY services/shared /shared
 
 # Copy package files
 COPY services/wallet-service/package*.json ./


### PR DESCRIPTION
- Change shared module copy destination from /app/shared to /shared
- This fixes the require('../../shared/...') paths in services
- Resolves MODULE_NOT_FOUND errors in Docker containers