### PR TITLE
Fix shared module dependencies in Dockerfiles

### DIFF
--- a/fraudwallet/services/auth-service/Dockerfile.dev
+++ b/fraudwallet/services/auth-service/Dockerfile.dev
@@ -2,14 +2,16 @@ FROM node:20-alpine
 
 WORKDIR /app
 
-# Copy package files
-COPY services/auth-service/package*.json ./
+# Install shared dependencies first
+COPY services/shared/package*.json /shared/
+RUN cd /shared && npm install
 
-# Install dependencies including dev dependencies
-RUN npm install
-
-# Copy shared dependencies to parent directory (so ../../shared works)
+# Copy rest of shared modules
 COPY services/shared /shared
+
+# Copy and install service dependencies
+COPY services/auth-service/package*.json ./
+RUN npm install
 
 # Copy source code
 COPY services/auth-service/src ./src

--- a/fraudwallet/services/fraud-detection-service/Dockerfile.dev
+++ b/fraudwallet/services/fraud-detection-service/Dockerfile.dev
@@ -1,9 +1,24 @@
 FROM node:20-alpine
+
 WORKDIR /app
+
+# Install shared dependencies first
+COPY services/shared/package*.json /shared/
+RUN cd /shared && npm install
+
+# Copy rest of shared modules
 COPY services/shared /shared
+
+# Copy and install service dependencies
 COPY services/fraud-detection-service/package*.json ./
 RUN npm install
+
+# Copy source code
 COPY services/fraud-detection-service/src ./src
 COPY services/fraud-detection-service/.env.example ./.env
+
+# Expose port
 EXPOSE 3005
+
+# Start with nodemon for hot reload
 CMD ["npm", "run", "dev"]

--- a/fraudwallet/services/splitpay-service/Dockerfile.dev
+++ b/fraudwallet/services/splitpay-service/Dockerfile.dev
@@ -1,9 +1,24 @@
 FROM node:20-alpine
+
 WORKDIR /app
+
+# Install shared dependencies first
+COPY services/shared/package*.json /shared/
+RUN cd /shared && npm install
+
+# Copy rest of shared modules
 COPY services/shared /shared
+
+# Copy and install service dependencies
 COPY services/splitpay-service/package*.json ./
 RUN npm install
+
+# Copy source code
 COPY services/splitpay-service/src ./src
 COPY services/splitpay-service/.env.example ./.env
+
+# Expose port
 EXPOSE 3004
+
+# Start with nodemon for hot reload
 CMD ["npm", "run", "dev"]

--- a/fraudwallet/services/user-service/Dockerfile.dev
+++ b/fraudwallet/services/user-service/Dockerfile.dev
@@ -2,13 +2,15 @@ FROM node:20-alpine
 
 WORKDIR /app
 
-# Copy shared dependencies
+# Install shared dependencies first
+COPY services/shared/package*.json /shared/
+RUN cd /shared && npm install
+
+# Copy rest of shared modules
 COPY services/shared /shared
 
-# Copy package files
+# Copy and install service dependencies
 COPY services/user-service/package*.json ./
-
-# Install dependencies including dev
 RUN npm install
 
 # Copy source code
@@ -18,5 +20,5 @@ COPY services/user-service/.env.example ./.env
 # Expose port
 EXPOSE 3002
 
-# Start with nodemon
+# Start with nodemon for hot reload
 CMD ["npm", "run", "dev"]

--- a/fraudwallet/services/wallet-service/Dockerfile.dev
+++ b/fraudwallet/services/wallet-service/Dockerfile.dev
@@ -2,13 +2,15 @@ FROM node:20-alpine
 
 WORKDIR /app
 
-# Copy shared dependencies
+# Install shared dependencies first
+COPY services/shared/package*.json /shared/
+RUN cd /shared && npm install
+
+# Copy rest of shared modules
 COPY services/shared /shared
 
-# Copy package files
+# Copy and install service dependencies
 COPY services/wallet-service/package*.json ./
-
-# Install dependencies including dev
 RUN npm install
 
 # Copy source code
@@ -18,5 +20,5 @@ COPY services/wallet-service/.env.example ./.env
 # Expose port
 EXPOSE 3003
 
-# Start with nodemon
+# Start with nodemon for hot reload
 CMD ["npm", "run", "dev"]


### PR DESCRIPTION
- Install shared/node_modules before copying shared directory
- This ensures pg, jsonwebtoken dependencies are available
- Fixes MODULE_NOT_FOUND errors for shared modules
- Applied to all microservice Dockerfiles