### PR TITLE
Fix frontend validation to match backend API requirements

### DIFF
--- a/fraudwallet/frontend/src/app/login/page.tsx
+++ b/fraudwallet/frontend/src/app/login/page.tsx
@@ -36,7 +36,7 @@ export default function LoginPage() {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          emailOrPhone,
+          identifier: emailOrPhone,
           password,
         }),
       })

--- a/fraudwallet/frontend/src/app/signup/page.tsx
+++ b/fraudwallet/frontend/src/app/signup/page.tsx
@@ -42,9 +42,17 @@ export default function SignupPage() {
       return
     }
 
-    // Check password length
-    if (formData.password.length < 6) {
-      setError("Password must be at least 6 characters")
+    // Validate password requirements (match backend validation)
+    if (formData.password.length < 8) {
+      setError("Password must be at least 8 characters")
+      return
+    }
+    if (!/[A-Z]/.test(formData.password)) {
+      setError("Password must contain at least one uppercase letter")
+      return
+    }
+    if (!/[0-9]/.test(formData.password)) {
+      setError("Password must contain at least one number")
       return
     }
 
@@ -208,6 +216,9 @@ export default function SignupPage() {
                       {showPassword ? <EyeOff className="h-5 w-5" /> : <Eye className="h-5 w-5" />}
                     </button>
                   </div>
+                  <p className="text-xs text-muted-foreground">
+                    Must be 8+ characters with uppercase and number
+                  </p>
                 </div>
 
                 <div className="space-y-2">


### PR DESCRIPTION
Login page:
- Change field name from 'emailOrPhone' to 'identifier' to match backend API expectation in authController.js:131

Signup page:
- Update password validation to require 8+ characters (was 6)
- Add validation for uppercase letter requirement
- Add validation for number requirement
- Add helper text to inform users of password requirements

These changes resolve the 400 validation errors that were occurring during login and signup attempts.