### PR TITLE
Fix wallet balance undefined/NaN errors

### DIFF
--- a/fraudwallet/frontend/src/components/dashboard-tab.tsx
+++ b/fraudwallet/frontend/src/components/dashboard-tab.tsx
@@ -129,13 +129,13 @@ export function DashboardTab() {
       })
       const balanceData = await balanceResponse.json()
       if (balanceData.success) {
-        setWalletBalance(balanceData.balance)
+        setWalletBalance(balanceData.balance ?? 0)
 
         // Update user data in localStorage
         const storedUser = localStorage.getItem("user")
         if (storedUser) {
           const userData = JSON.parse(storedUser)
-          userData.walletBalance = balanceData.balance
+          userData.walletBalance = balanceData.balance ?? 0
           localStorage.setItem("user", JSON.stringify(userData))
           setUser(userData)
         }
@@ -295,7 +295,7 @@ export function DashboardTab() {
       <Card className="relative overflow-hidden bg-gradient-to-br from-primary to-primary/80 p-6 text-primary-foreground">
         <div className="relative z-10">
           <p className="text-sm opacity-90">Wallet Balance</p>
-          <h2 className="mt-2 text-4xl font-bold">RM {walletBalance.toFixed(2)}</h2>
+          <h2 className="mt-2 text-4xl font-bold">RM {(walletBalance ?? 0).toFixed(2)}</h2>
           <div className="mt-4">
             <Button
               onClick={() => setShowAddFundsModal(true)}

--- a/fraudwallet/services/wallet-service/src/controllers/walletController.js
+++ b/fraudwallet/services/wallet-service/src/controllers/walletController.js
@@ -57,7 +57,7 @@ exports.getBalance = async (req, res) => {
     }
 
     return ResponseHandler.success(res, {
-      balance: parseFloat(result.rows[0].wallet_balance)
+      balance: parseFloat(result.rows[0].wallet_balance) || 0
     }, 'Balance retrieved successfully');
 
   } catch (error) {


### PR DESCRIPTION
Resolves "Cannot read properties of undefined (reading 'toFixed')" error on dashboard.

Backend changes (wallet-service):
- Add fallback to 0 when wallet_balance is null/NaN: parseFloat() || 0
- Ensures balance API always returns a valid number

Frontend changes (dashboard-tab.tsx):
- Use nullish coalescing (?? 0) when setting walletBalance state
- Add fallback in display: (walletBalance ?? 0).toFixed(2)
- Ensure localStorage always stores valid balance value

This prevents runtime errors when users have null balances in the database.