### PR TITLE
Fix transactions array undefined error on dashboard

### DIFF
--- a/fraudwallet/frontend/src/components/dashboard-tab.tsx
+++ b/fraudwallet/frontend/src/components/dashboard-tab.tsx
@@ -149,7 +149,7 @@ export function DashboardTab() {
       })
       const transactionsData = await transactionsResponse.json()
       if (transactionsData.success) {
-        setTransactions(transactionsData.transactions)
+        setTransactions(transactionsData.transactions || [])
       }
     } catch (err) {
       console.error("Load wallet data error:", err)
@@ -340,7 +340,7 @@ export function DashboardTab() {
         <div className="mb-4 flex items-center justify-between">
           <h3 className="font-semibold">Recent Transactions</h3>
         </div>
-        {transactions.length === 0 ? (
+        {(transactions || []).length === 0 ? (
           <Card className="p-6 text-center text-muted-foreground">
             <Wallet className="h-12 w-12 mx-auto mb-2 opacity-50" />
             <p>No transactions yet</p>
@@ -348,7 +348,7 @@ export function DashboardTab() {
           </Card>
         ) : (
           <div className="space-y-3">
-            {transactions.map((transaction) => (
+            {(transactions || []).map((transaction) => (
               <Card key={transaction.id} className="flex items-center justify-between p-4">
                 <div className="flex items-center gap-3">
                   <div


### PR DESCRIPTION
Resolves "Cannot read properties of undefined (reading 'length')" error.

Frontend changes (dashboard-tab.tsx):
- Add fallback when setting transactions state: || []
- Use nullish coalescing in JSX: (transactions || []).length
- Safeguard .map() call with (transactions || []).map()

This ensures the transactions array is always defined, even if the API returns undefined or the state gets corrupted.