### PR TITLE
Fix root cause: Invalid password hashes in seed data

### DIFF
--- a/fraudwallet/services/diagnose-issues.sh
+++ b/fraudwallet/services/diagnose-issues.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Diagnostic script to identify what's not working
+
+echo "🔍 FraudWallet Diagnostics"
+echo "========================================"
+echo ""
+
+# Check database users
+echo "📊 Database Users:"
+echo "-------------------"
+docker exec fraudwallet-postgres-dev psql -U postgres -d fraudwallet -c "SELECT id, email, full_name, account_id, created_at FROM users ORDER BY id LIMIT 10;"
+echo ""
+
+# Try manual login with alice
+echo "🔐 Testing Login with alice@example.com:"
+echo "-------------------"
+RESPONSE=$(curl -s -w "\n%{http_code}" -X POST http://localhost:8080/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email":"alice@example.com","password":"password123"}')
+HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
+BODY=$(echo "$RESPONSE" | head -n-1)
+echo "HTTP Code: $HTTP_CODE"
+echo "Response: $BODY"
+echo ""
+
+# Try manual login with bob
+echo "🔐 Testing Login with bob@example.com:"
+echo "-------------------"
+RESPONSE=$(curl -s -w "\n%{http_code}" -X POST http://localhost:8080/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email":"bob@example.com","password":"password123"}')
+HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
+BODY=$(echo "$RESPONSE" | head -n-1)
+echo "HTTP Code: $HTTP_CODE"
+echo "Response: $BODY"
+echo ""
+
+# Check auth service logs
+echo "📋 Auth Service Logs (last 20 lines):"
+echo "-------------------"
+docker logs fraudwallet-auth-service --tail 20
+echo ""
+
+# Check API Gateway logs
+echo "📋 API Gateway Logs (last 20 lines):"
+echo "-------------------"
+docker logs fraudwallet-api-gateway --tail 20
+echo ""
+
+echo "========================================"
+echo "✅ Diagnostics Complete"

--- a/fraudwallet/services/fix-database-passwords.sh
+++ b/fraudwallet/services/fix-database-passwords.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+set -e
+
+echo "🔧 Fixing FraudWallet Database Password Hashes"
+echo "=============================================="
+echo ""
+
+# Step 1: Generate proper bcrypt hash for Test1234!
+echo "📝 Step 1: Generating bcrypt hash for password 'Test1234!'..."
+HASH=$(docker exec fraudwallet-auth-service node -e "const bcrypt = require('bcrypt'); bcrypt.hash('Test1234!', 10).then(hash => console.log(hash))")
+echo "✅ Hash generated: $HASH"
+echo ""
+
+# Step 2: Update seed.sql with the proper hash
+echo "📝 Step 2: Updating seed.sql with proper password hash..."
+sed -i "s/\$2b\$10\$YourBcryptHashHere/$HASH/g" shared/database/seed.sql
+echo "✅ seed.sql updated"
+echo ""
+
+# Step 3: Drop and recreate database
+echo "📝 Step 3: Dropping existing database..."
+docker exec fraudwallet-postgres-dev psql -U postgres -c "DROP DATABASE IF EXISTS fraudwallet;"
+echo "✅ Database dropped"
+echo ""
+
+echo "📝 Step 4: Creating fresh database..."
+docker exec fraudwallet-postgres-dev psql -U postgres -c "CREATE DATABASE fraudwallet;"
+echo "✅ Database created"
+echo ""
+
+# Step 4: Run schema
+echo "📝 Step 5: Running database schema..."
+docker exec -i fraudwallet-postgres-dev psql -U postgres -d fraudwallet < shared/database/schema.sql
+echo "✅ Schema applied"
+echo ""
+
+# Step 5: Run updated seed data
+echo "📝 Step 6: Running updated seed data..."
+docker exec -i fraudwallet-postgres-dev psql -U postgres -d fraudwallet < shared/database/seed.sql
+echo "✅ Seed data loaded"
+echo ""
+
+# Step 6: Verify users
+echo "📝 Step 7: Verifying seeded users..."
+echo ""
+docker exec fraudwallet-postgres-dev psql -U postgres -d fraudwallet -c "SELECT id, email, full_name, account_id, wallet_balance FROM users;"
+echo ""
+
+# Step 7: Test login
+echo "📝 Step 8: Testing login with john@test.com..."
+RESPONSE=$(curl -s -X POST http://localhost:8080/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email":"john@test.com","password":"Test1234!"}')
+
+echo "Response: $RESPONSE"
+echo ""
+
+if echo "$RESPONSE" | grep -q '"success":true'; then
+  echo "✅ Login successful!"
+  echo ""
+  echo "=============================================="
+  echo "🎉 DATABASE FIXED!"
+  echo "=============================================="
+  echo ""
+  echo "Test users are now ready with password: Test1234!"
+  echo "  - john@test.com / Test1234!"
+  echo "  - jane@test.com / Test1234!"
+  echo "  - bob@test.com / Test1234!"
+  echo "  - alice@test.com / Test1234!"
+else
+  echo "⚠️  Login test failed. Response:"
+  echo "$RESPONSE"
+fi

--- a/fraudwallet/services/fix-seed-passwords.js
+++ b/fraudwallet/services/fix-seed-passwords.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+
+/**
+ * Generate proper bcrypt hashes for seed data passwords
+ */
+
+const bcrypt = require('bcrypt');
+
+const password = 'Test1234!';
+const saltRounds = 10;
+
+async function generateHashes() {
+  console.log('Generating bcrypt hash for password: Test1234!');
+  console.log('This will be used for all test users\n');
+
+  try {
+    const hash = await bcrypt.hash(password, saltRounds);
+    console.log('Generated hash:');
+    console.log(hash);
+    console.log('\n✅ Copy this hash into seed.sql to replace $2b$10$YourBcryptHashHere');
+    console.log('\nTest users will be:');
+    console.log('  - john@test.com / Test1234!');
+    console.log('  - jane@test.com / Test1234!');
+    console.log('  - bob@test.com / Test1234!');
+    console.log('  - alice@test.com / Test1234!');
+  } catch (error) {
+    console.error('Error generating hash:', error);
+  }
+}
+
+generateHashes();

--- a/fraudwallet/services/generate-hash.sh
+++ b/fraudwallet/services/generate-hash.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Generate bcrypt hash for Test1234! using the auth-service container
+
+echo "🔐 Generating bcrypt hash for password: Test1234!"
+echo ""
+
+HASH=$(docker exec fraudwallet-auth-service node -e "const bcrypt = require('bcrypt'); bcrypt.hash('Test1234!', 10).then(hash => console.log(hash))")
+
+echo "✅ Generated hash:"
+echo "$HASH"
+echo ""
+echo "📝 Use this hash to replace '\$2b\$10\$YourBcryptHashHere' in seed.sql"

--- a/fraudwallet/services/test-all-features.sh
+++ b/fraudwallet/services/test-all-features.sh
@@ -94,8 +94,8 @@ echo ""
 echo "🔐 AUTHENTICATION TESTS"
 echo "------------------------"
 
-# Try to login with existing test account (alice from seed data)
-LOGIN_DATA='{"identifier":"alice@example.com","password":"password123"}'
+# Try to login with existing test account (john from seed data)
+LOGIN_DATA='{"identifier":"john@test.com","password":"Test1234!"}'
 LOGIN_RESPONSE=$(curl -s -X POST "http://localhost:8080/api/auth/login" \
     -H "Content-Type: application/json" \
     -d "$LOGIN_DATA")
@@ -103,13 +103,13 @@ LOGIN_RESPONSE=$(curl -s -X POST "http://localhost:8080/api/auth/login" \
 TOKEN=$(echo "$LOGIN_RESPONSE" | grep -o '"token":"[^"]*' | sed 's/"token":"//')
 
 if [ ! -z "$TOKEN" ]; then
-    echo -e "${GREEN}✅ Login successful${NC} (Token obtained for alice@example.com)"
+    echo -e "${GREEN}✅ Login successful${NC} (Token obtained for john@test.com)"
     ((PASS++))
 else
     echo -e "${YELLOW}⚠️  Could not login with test account${NC}"
-    echo "   Trying bob@example.com..."
+    echo "   Trying jane@test.com..."
 
-    LOGIN_DATA='{"identifier":"bob@example.com","password":"password123"}'
+    LOGIN_DATA='{"identifier":"jane@test.com","password":"Test1234!"}'
     LOGIN_RESPONSE=$(curl -s -X POST "http://localhost:8080/api/auth/login" \
         -H "Content-Type: application/json" \
         -d "$LOGIN_DATA")
@@ -117,7 +117,7 @@ else
     TOKEN=$(echo "$LOGIN_RESPONSE" | grep -o '"token":"[^"]*' | sed 's/"token":"//')
 
     if [ ! -z "$TOKEN" ]; then
-        echo -e "${GREEN}✅ Login successful${NC} (Token obtained for bob@example.com)"
+        echo -e "${GREEN}✅ Login successful${NC} (Token obtained for jane@test.com)"
         ((PASS++))
     fi
 fi


### PR DESCRIPTION
PROBLEM IDENTIFIED:
- seed.sql contained placeholder hash '$2b$10$YourBcryptHashHere'
- This is NOT a valid bcrypt hash, preventing all logins
- Test script was using wrong credentials (alice@example.com instead of john@test.com)

ROOT CAUSE: Why "many things not working"
- No users could log in because password hashes were invalid
- This blocked all authenticated features (profile, wallet, splits, etc.)

FIXES:
1. Added fix-database-passwords.sh - Regenerates database with proper bcrypt hashes
2. Added generate-hash.sh - Utility to generate bcrypt hash for Test1234!
3. Added diagnose-issues.sh - Diagnostic script to check database and auth
4. Updated test-all-features.sh - Use correct credentials (john@test.com / Test1234!)

TO FIX THE DATABASE:
Run: ./fix-database-passwords.sh

This will:
- Generate proper bcrypt hash for 'Test1234!'
- Update seed.sql with the hash
- Drop and recreate database
- Load corrected seed data
- Test login to verify fix

Test users will have password: Test1234!
- john@test.com
- jane@test.com
- bob@test.com
- alice@test.com