### PR TITLE
Fix: Strip markdown code blocks from Gemini JSON responses

### DIFF
--- a/fraudwallet/backend/src/fraud-detection/geminiAI.js
+++ b/fraudwallet/backend/src/fraud-detection/geminiAI.js
@@ -108,13 +108,21 @@ class GeminiFraudDetector {
       });
 
       // Parse JSON response
-      const analysisText = response.text;
+      let analysisText = response.text;
       let analysis;
+
+      // Strip markdown code blocks if present (```json ... ```)
+      if (analysisText.includes('```json')) {
+        analysisText = analysisText.replace(/```json\s*/g, '').replace(/```\s*/g, '').trim();
+      } else if (analysisText.includes('```')) {
+        analysisText = analysisText.replace(/```\s*/g, '').trim();
+      }
 
       try {
         analysis = JSON.parse(analysisText);
       } catch (parseError) {
         console.error('Failed to parse AI response as JSON:', analysisText);
+        console.error('Parse error:', parseError.message);
         throw new Error('Invalid JSON response from AI');
       }
 


### PR DESCRIPTION
Issue: Gemini returns JSON wrapped in markdown code blocks
Example: ```json {...} ```

Solution:
- Added markdown stripping before JSON parsing
- Handles both ```json and ``` formats
- Improved error logging with parse details

This allows proper parsing of Gemini's actual responses which often include markdown formatting despite responseMimeType setting.

Testing: AI fraud detection now works correctly with Gemini API