### PR TITLE
Fix: Add empty state for fraud dashboard when no data exists

### DIFF
--- a/fraudwallet/frontend/src/components/fraud-dashboard-tab.tsx
+++ b/fraudwallet/frontend/src/components/fraud-dashboard-tab.tsx
@@ -218,7 +218,7 @@ export function FraudDashboardTab() {
         {activeView === "overview" && (
           <>
             {/* Trustworthiness Health Bar */}
-            {userStats && (
+            {userStats && userStats.total_checks > 0 && (
               <Card className="p-4">
                 <div className="space-y-3">
                   <div className="flex items-center justify-between">
@@ -258,6 +258,22 @@ export function FraudDashboardTab() {
               </Card>
             )}
 
+            {/* No Data State */}
+            {(!systemMetrics || systemMetrics.totalChecks === 0) && (
+              <Card className="p-6 text-center">
+                <Shield className="h-16 w-16 mx-auto mb-4 text-muted-foreground/50" />
+                <h3 className="font-semibold text-lg mb-2">No Fraud Data Yet</h3>
+                <p className="text-sm text-muted-foreground mb-4">
+                  Start making transactions to see your fraud detection analytics here.
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  Your transactions will be automatically analyzed for fraud risk and displayed on this dashboard.
+                </p>
+              </Card>
+            )}
+
+            {/* Metrics Cards - Only show if we have data */}
+            {systemMetrics && systemMetrics.totalChecks > 0 && (
             <div className="grid grid-cols-2 gap-4">
             <Card className="p-4">
               <div className="flex items-center justify-between">
@@ -311,8 +327,10 @@ export function FraudDashboardTab() {
               </div>
             </Card>
           </div>
+          )}
 
           {/* Quick Actions */}
+          {systemMetrics && systemMetrics.totalChecks > 0 && (
           <div className="grid grid-cols-3 gap-2">
             <Button
               onClick={() => setActiveView("high-risk")}
@@ -339,6 +357,7 @@ export function FraudDashboardTab() {
               Recent Logs
             </Button>
           </div>
+          )}
           </>
         )}
 


### PR DESCRIPTION
- Added 'No Fraud Data Yet' empty state with helpful message
- Hide metrics cards and quick action buttons when totalChecks is 0
- Hide trustworthiness health bar when user has no transactions
- Dashboard now clearly indicates to users they need to make transactions first
- Prevents confusion from showing all zeros which looks like a broken system