### PR TITLE
Fix: Resolve build error and always show metrics with zeros

### DIFF
--- a/fraudwallet/frontend/src/components/fraud-dashboard-tab.tsx
+++ b/fraudwallet/frontend/src/components/fraud-dashboard-tab.tsx
@@ -254,17 +254,12 @@ export function FraudDashboardTab() {
         {activeView === "overview" && (
           <>
             {/* Trustworthiness Health Bar */}
-            {userStats && userStats.total_checks > 0 && (
-              <Card className="p-4">
-                <div className="space-y-3">
-                  <div className="flex items-center justify-between">
-                    <div className="flex items-center gap-2">
-                      <Heart className={`h-5 w-5 ${getTrustworthinessLevel(userStats.avg_risk_score || 0).textColor}`} />
-                      <h3 className="font-semibold">Account Trustworthiness</h3>
-                    </div>
-                    <span className={`text-sm font-bold ${getTrustworthinessLevel(userStats.avg_risk_score || 0).textColor}`}>
-                      {getTrustworthinessLevel(userStats.avg_risk_score || 0).level}
-                    </span>
+            <Card className="p-4">
+              <div className="space-y-3">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <Heart className={`h-5 w-5 ${getTrustworthinessLevel(userStats?.avg_risk_score || 0).textColor}`} />
+                    <h3 className="font-semibold">Account Trustworthiness</h3>
                   </div>
                   <span className={`text-sm font-bold ${getTrustworthinessLevel(userStats?.avg_risk_score || 0).textColor}`}>
                     {getTrustworthinessLevel(userStats?.avg_risk_score || 0).level}
@@ -297,22 +292,6 @@ export function FraudDashboardTab() {
               </div>
             </Card>
 
-            {/* No Data State */}
-            {(!systemMetrics || systemMetrics.totalChecks === 0) && (
-              <Card className="p-6 text-center">
-                <Shield className="h-16 w-16 mx-auto mb-4 text-muted-foreground/50" />
-                <h3 className="font-semibold text-lg mb-2">No Fraud Data Yet</h3>
-                <p className="text-sm text-muted-foreground mb-4">
-                  Start making transactions to see your fraud detection analytics here.
-                </p>
-                <p className="text-xs text-muted-foreground">
-                  Your transactions will be automatically analyzed for fraud risk and displayed on this dashboard.
-                </p>
-              </Card>
-            )}
-
-            {/* Metrics Cards - Only show if we have data */}
-            {systemMetrics && systemMetrics.totalChecks > 0 && (
             <div className="grid grid-cols-2 gap-4">
             <Card className="p-4">
               <div className="flex items-center justify-between">
@@ -366,10 +345,8 @@ export function FraudDashboardTab() {
               </div>
             </Card>
           </div>
-          )}
 
           {/* Quick Actions */}
-          {systemMetrics && systemMetrics.totalChecks > 0 && (
           <div className="grid grid-cols-3 gap-2">
             <Button
               onClick={() => setActiveView("high-risk")}
@@ -396,7 +373,6 @@ export function FraudDashboardTab() {
               Recent Logs
             </Button>
           </div>
-          )}
           </>
         )}
 


### PR DESCRIPTION
- Fixed duplicate JSX code causing syntax error
- Removed conditional rendering that was hiding metrics when no data
- Removed "No Data State" card that conflicted with always-visible metrics
- Always displays trustworthiness bar and all metric cards with zeros
- Proper optional chaining for safe property access