### PR TITLE
Add transaction passcode authentication for secure payments

### DIFF
--- a/fraudwallet/backend/src/database.js
+++ b/fraudwallet/backend/src/database.js
@@ -90,6 +90,21 @@ const createUsersTable = () => {
       db.exec("ALTER TABLE users ADD COLUMN role TEXT DEFAULT 'user'");
       console.log('✅ Added role column');
     }
+
+    if (!columnNames.includes('transaction_passcode')) {
+      db.exec("ALTER TABLE users ADD COLUMN transaction_passcode TEXT");
+      console.log('✅ Added transaction_passcode column');
+    }
+
+    if (!columnNames.includes('passcode_attempts')) {
+      db.exec("ALTER TABLE users ADD COLUMN passcode_attempts INTEGER DEFAULT 0");
+      console.log('✅ Added passcode_attempts column');
+    }
+
+    if (!columnNames.includes('passcode_locked_until')) {
+      db.exec("ALTER TABLE users ADD COLUMN passcode_locked_until DATETIME");
+      console.log('✅ Added passcode_locked_until column');
+    }
   } catch (error) {
     console.error('Error adding columns:', error.message);
   }

--- a/fraudwallet/backend/src/passcode.js
+++ b/fraudwallet/backend/src/passcode.js
@@ -1,0 +1,252 @@
+// Transaction Passcode Management
+const bcrypt = require('bcrypt');
+const db = require('./database');
+
+const SALT_ROUNDS = 10;
+const MAX_ATTEMPTS = 3;
+const LOCKOUT_DURATION_MINUTES = 15;
+
+/**
+ * Validate passcode format (6 digits only)
+ */
+const validatePasscodeFormat = (passcode) => {
+  if (!passcode) {
+    return { valid: false, message: 'Passcode is required' };
+  }
+
+  if (typeof passcode !== 'string') {
+    return { valid: false, message: 'Passcode must be a string' };
+  }
+
+  if (passcode.length !== 6) {
+    return { valid: false, message: 'Passcode must be exactly 6 digits' };
+  }
+
+  if (!/^\d{6}$/.test(passcode)) {
+    return { valid: false, message: 'Passcode must contain only numbers' };
+  }
+
+  return { valid: true };
+};
+
+/**
+ * Check if user has a passcode set up
+ */
+const hasPasscode = (userId) => {
+  try {
+    const user = db.prepare('SELECT transaction_passcode FROM users WHERE id = ?').get(userId);
+    return user && user.transaction_passcode !== null;
+  } catch (error) {
+    console.error('Error checking passcode existence:', error);
+    throw error;
+  }
+};
+
+/**
+ * Check if user is currently locked out due to too many failed attempts
+ */
+const isLockedOut = (userId) => {
+  try {
+    const user = db.prepare('SELECT passcode_locked_until FROM users WHERE id = ?').get(userId);
+
+    if (!user || !user.passcode_locked_until) {
+      return false;
+    }
+
+    const lockoutTime = new Date(user.passcode_locked_until);
+    const now = new Date();
+
+    if (now < lockoutTime) {
+      const minutesRemaining = Math.ceil((lockoutTime - now) / 60000);
+      return { locked: true, minutesRemaining };
+    }
+
+    // Lockout expired, reset attempts
+    db.prepare('UPDATE users SET passcode_attempts = 0, passcode_locked_until = NULL WHERE id = ?').run(userId);
+    return false;
+  } catch (error) {
+    console.error('Error checking lockout status:', error);
+    throw error;
+  }
+};
+
+/**
+ * Set or update transaction passcode for a user
+ */
+const setPasscode = async (userId, passcode, currentPassword) => {
+  try {
+    // Validate passcode format
+    const validation = validatePasscodeFormat(passcode);
+    if (!validation.valid) {
+      return { success: false, message: validation.message };
+    }
+
+    // Verify current password for security
+    const user = db.prepare('SELECT password_hash FROM users WHERE id = ?').get(userId);
+    if (!user) {
+      return { success: false, message: 'User not found' };
+    }
+
+    const passwordMatch = await bcrypt.compare(currentPassword, user.password_hash);
+    if (!passwordMatch) {
+      return { success: false, message: 'Invalid password' };
+    }
+
+    // Hash the passcode
+    const hashedPasscode = await bcrypt.hash(passcode, SALT_ROUNDS);
+
+    // Update user's passcode
+    db.prepare('UPDATE users SET transaction_passcode = ?, passcode_attempts = 0, passcode_locked_until = NULL, updated_at = CURRENT_TIMESTAMP WHERE id = ?')
+      .run(hashedPasscode, userId);
+
+    return { success: true, message: 'Transaction passcode set successfully' };
+  } catch (error) {
+    console.error('Error setting passcode:', error);
+    return { success: false, message: 'Failed to set passcode' };
+  }
+};
+
+/**
+ * Verify transaction passcode
+ */
+const verifyPasscode = async (userId, passcode) => {
+  try {
+    // Validate passcode format
+    const validation = validatePasscodeFormat(passcode);
+    if (!validation.valid) {
+      return { success: false, message: validation.message };
+    }
+
+    // Check if user is locked out
+    const lockoutStatus = isLockedOut(userId);
+    if (lockoutStatus && lockoutStatus.locked) {
+      return {
+        success: false,
+        message: `Too many failed attempts. Please try again in ${lockoutStatus.minutesRemaining} minute(s)`,
+        locked: true
+      };
+    }
+
+    // Get user's passcode
+    const user = db.prepare('SELECT transaction_passcode, passcode_attempts FROM users WHERE id = ?').get(userId);
+
+    if (!user || !user.transaction_passcode) {
+      return { success: false, message: 'Transaction passcode not set up' };
+    }
+
+    // Verify passcode
+    const passcodeMatch = await bcrypt.compare(passcode, user.transaction_passcode);
+
+    if (passcodeMatch) {
+      // Success - reset attempts
+      db.prepare('UPDATE users SET passcode_attempts = 0, passcode_locked_until = NULL WHERE id = ?').run(userId);
+      return { success: true, message: 'Passcode verified' };
+    } else {
+      // Failed attempt
+      const newAttempts = (user.passcode_attempts || 0) + 1;
+
+      if (newAttempts >= MAX_ATTEMPTS) {
+        // Lock out user
+        const lockoutUntil = new Date();
+        lockoutUntil.setMinutes(lockoutUntil.getMinutes() + LOCKOUT_DURATION_MINUTES);
+
+        db.prepare('UPDATE users SET passcode_attempts = ?, passcode_locked_until = ? WHERE id = ?')
+          .run(newAttempts, lockoutUntil.toISOString(), userId);
+
+        return {
+          success: false,
+          message: `Too many failed attempts. Your account is locked for ${LOCKOUT_DURATION_MINUTES} minutes`,
+          locked: true
+        };
+      } else {
+        // Increment attempts
+        db.prepare('UPDATE users SET passcode_attempts = ? WHERE id = ?').run(newAttempts, userId);
+
+        const remainingAttempts = MAX_ATTEMPTS - newAttempts;
+        return {
+          success: false,
+          message: `Incorrect passcode. ${remainingAttempts} attempt(s) remaining`,
+          remainingAttempts
+        };
+      }
+    }
+  } catch (error) {
+    console.error('Error verifying passcode:', error);
+    return { success: false, message: 'Failed to verify passcode' };
+  }
+};
+
+/**
+ * Change transaction passcode (requires old passcode)
+ */
+const changePasscode = async (userId, oldPasscode, newPasscode) => {
+  try {
+    // Validate new passcode format
+    const validation = validatePasscodeFormat(newPasscode);
+    if (!validation.valid) {
+      return { success: false, message: validation.message };
+    }
+
+    // Check if user is locked out
+    const lockoutStatus = isLockedOut(userId);
+    if (lockoutStatus && lockoutStatus.locked) {
+      return {
+        success: false,
+        message: `Too many failed attempts. Please try again in ${lockoutStatus.minutesRemaining} minute(s)`
+      };
+    }
+
+    // Verify old passcode first
+    const verifyResult = await verifyPasscode(userId, oldPasscode);
+    if (!verifyResult.success) {
+      return verifyResult;
+    }
+
+    // Hash the new passcode
+    const hashedPasscode = await bcrypt.hash(newPasscode, SALT_ROUNDS);
+
+    // Update passcode
+    db.prepare('UPDATE users SET transaction_passcode = ?, passcode_attempts = 0, passcode_locked_until = NULL, updated_at = CURRENT_TIMESTAMP WHERE id = ?')
+      .run(hashedPasscode, userId);
+
+    return { success: true, message: 'Transaction passcode changed successfully' };
+  } catch (error) {
+    console.error('Error changing passcode:', error);
+    return { success: false, message: 'Failed to change passcode' };
+  }
+};
+
+/**
+ * Get passcode status for a user
+ */
+const getPasscodeStatus = (userId) => {
+  try {
+    const user = db.prepare('SELECT transaction_passcode, passcode_attempts, passcode_locked_until FROM users WHERE id = ?').get(userId);
+
+    if (!user) {
+      return { hasPasscode: false, isLocked: false };
+    }
+
+    const lockoutStatus = isLockedOut(userId);
+
+    return {
+      hasPasscode: user.transaction_passcode !== null,
+      isLocked: lockoutStatus && lockoutStatus.locked ? true : false,
+      attempts: user.passcode_attempts || 0,
+      lockoutMinutes: lockoutStatus && lockoutStatus.locked ? lockoutStatus.minutesRemaining : 0
+    };
+  } catch (error) {
+    console.error('Error getting passcode status:', error);
+    throw error;
+  }
+};
+
+module.exports = {
+  validatePasscodeFormat,
+  hasPasscode,
+  isLockedOut,
+  setPasscode,
+  verifyPasscode,
+  changePasscode,
+  getPasscodeStatus
+};

--- a/fraudwallet/backend/src/passcodeAPI.js
+++ b/fraudwallet/backend/src/passcodeAPI.js
@@ -1,0 +1,145 @@
+// Transaction Passcode API endpoints
+const {
+  setPasscode,
+  verifyPasscode,
+  changePasscode,
+  getPasscodeStatus
+} = require('./passcode');
+
+/**
+ * Set or update transaction passcode
+ * POST /api/user/passcode/set
+ * Body: { passcode, currentPassword }
+ */
+const setUserPasscode = async (req, res) => {
+  try {
+    const { passcode, currentPassword } = req.body;
+    const userId = req.user.userId;
+
+    if (!passcode || !currentPassword) {
+      return res.status(400).json({
+        success: false,
+        message: 'Passcode and current password are required'
+      });
+    }
+
+    const result = await setPasscode(userId, passcode, currentPassword);
+
+    if (result.success) {
+      return res.status(200).json(result);
+    } else {
+      return res.status(400).json(result);
+    }
+  } catch (error) {
+    console.error('Error in setUserPasscode:', error);
+    return res.status(500).json({
+      success: false,
+      message: 'Failed to set passcode'
+    });
+  }
+};
+
+/**
+ * Verify transaction passcode
+ * POST /api/user/passcode/verify
+ * Body: { passcode }
+ */
+const verifyUserPasscode = async (req, res) => {
+  try {
+    const { passcode } = req.body;
+    const userId = req.user.userId;
+
+    if (!passcode) {
+      return res.status(400).json({
+        success: false,
+        message: 'Passcode is required'
+      });
+    }
+
+    const result = await verifyPasscode(userId, passcode);
+
+    if (result.success) {
+      return res.status(200).json(result);
+    } else {
+      // Return 401 for authentication failure, 429 for too many attempts
+      const statusCode = result.locked ? 429 : 401;
+      return res.status(statusCode).json(result);
+    }
+  } catch (error) {
+    console.error('Error in verifyUserPasscode:', error);
+    return res.status(500).json({
+      success: false,
+      message: 'Failed to verify passcode'
+    });
+  }
+};
+
+/**
+ * Change transaction passcode
+ * POST /api/user/passcode/change
+ * Body: { oldPasscode, newPasscode }
+ */
+const changeUserPasscode = async (req, res) => {
+  try {
+    const { oldPasscode, newPasscode } = req.body;
+    const userId = req.user.userId;
+
+    if (!oldPasscode || !newPasscode) {
+      return res.status(400).json({
+        success: false,
+        message: 'Old passcode and new passcode are required'
+      });
+    }
+
+    if (oldPasscode === newPasscode) {
+      return res.status(400).json({
+        success: false,
+        message: 'New passcode must be different from old passcode'
+      });
+    }
+
+    const result = await changePasscode(userId, oldPasscode, newPasscode);
+
+    if (result.success) {
+      return res.status(200).json(result);
+    } else {
+      const statusCode = result.locked ? 429 : 401;
+      return res.status(statusCode).json(result);
+    }
+  } catch (error) {
+    console.error('Error in changeUserPasscode:', error);
+    return res.status(500).json({
+      success: false,
+      message: 'Failed to change passcode'
+    });
+  }
+};
+
+/**
+ * Get passcode status (whether user has set up passcode)
+ * GET /api/user/passcode/status
+ */
+const getUserPasscodeStatus = (req, res) => {
+  try {
+    const userId = req.user.userId;
+    const status = getPasscodeStatus(userId);
+
+    return res.status(200).json({
+      success: true,
+      ...status
+    });
+  } catch (error) {
+    console.error('Error in getUserPasscodeStatus:', error);
+    return res.status(500).json({
+      success: false,
+      message: 'Failed to get passcode status'
+    });
+  }
+};
+
+module.exports = {
+  setUserPasscode,
+  verifyUserPasscode,
+  changeUserPasscode,
+  getUserPasscodeStatus
+};

--- a/fraudwallet/backend/src/server.js
+++ b/fraudwallet/backend/src/server.js
@@ -55,6 +55,13 @@ app.post('/api/user/2fa/send-disable-code', verifyToken, user.sendDisableCode);
 app.put('/api/user/2fa/method', verifyToken, user.update2FAMethod);
 app.post('/api/user/2fa/test', verifyToken, user.send2FATest);
 
+// Transaction passcode routes (protected)
+const passcodeAPI = require('./passcodeAPI');
+app.post('/api/user/passcode/set', verifyToken, passcodeAPI.setUserPasscode);
+app.post('/api/user/passcode/verify', verifyToken, passcodeAPI.verifyUserPasscode);
+app.post('/api/user/passcode/change', verifyToken, passcodeAPI.changeUserPasscode);
+app.get('/api/user/passcode/status', verifyToken, passcodeAPI.getUserPasscodeStatus);
+
 // Payment routes (protected)
 app.post('/api/payment/lookup-recipient', verifyToken, user.lookupRecipient);
 

--- a/fraudwallet/frontend/src/components/passcode-dialog.tsx
+++ b/fraudwallet/frontend/src/components/passcode-dialog.tsx
@@ -1,0 +1,282 @@
+"use client"
+
+import * as React from "react"
+import { Lock, AlertCircle } from "lucide-react"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import {
+  InputOTP,
+  InputOTPGroup,
+  InputOTPSlot,
+} from "@/components/ui/input-otp"
+
+interface PasscodeDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  mode: "verify" | "setup" | "change"
+  title?: string
+  description?: string
+  onSubmit: (passcode: string, oldPasscode?: string) => Promise<{ success: boolean; message?: string; locked?: boolean }>
+  requireOldPasscode?: boolean
+}
+
+export function PasscodeDialog({
+  open,
+  onOpenChange,
+  mode,
+  title,
+  description,
+  onSubmit,
+  requireOldPasscode = false
+}: PasscodeDialogProps) {
+  const [passcode, setPasscode] = React.useState("")
+  const [oldPasscode, setOldPasscode] = React.useState("")
+  const [confirmPasscode, setConfirmPasscode] = React.useState("")
+  const [step, setStep] = React.useState<"old" | "new" | "confirm" | "single">(
+    mode === "change" ? "old" : mode === "setup" ? "new" : "single"
+  )
+  const [error, setError] = React.useState("")
+  const [isLoading, setIsLoading] = React.useState(false)
+
+  // Reset state when dialog opens/closes
+  React.useEffect(() => {
+    if (open) {
+      setPasscode("")
+      setOldPasscode("")
+      setConfirmPasscode("")
+      setError("")
+      setIsLoading(false)
+      if (mode === "change") {
+        setStep("old")
+      } else if (mode === "setup") {
+        setStep("new")
+      } else {
+        setStep("single")
+      }
+    }
+  }, [open, mode])
+
+  const handleSubmit = async () => {
+    setError("")
+    setIsLoading(true)
+
+    try {
+      if (mode === "setup") {
+        // Setup mode - requires new passcode and confirmation
+        if (step === "new") {
+          if (passcode.length !== 6) {
+            setError("Passcode must be 6 digits")
+            setIsLoading(false)
+            return
+          }
+          setStep("confirm")
+          setIsLoading(false)
+          return
+        } else if (step === "confirm") {
+          if (confirmPasscode !== passcode) {
+            setError("Passcodes do not match")
+            setIsLoading(false)
+            return
+          }
+          const result = await onSubmit(passcode)
+          if (result.success) {
+            onOpenChange(false)
+          } else {
+            setError(result.message || "Failed to set passcode")
+          }
+        }
+      } else if (mode === "change") {
+        // Change mode - requires old passcode, new passcode, and confirmation
+        if (step === "old") {
+          if (oldPasscode.length !== 6) {
+            setError("Passcode must be 6 digits")
+            setIsLoading(false)
+            return
+          }
+          setStep("new")
+          setIsLoading(false)
+          return
+        } else if (step === "new") {
+          if (passcode.length !== 6) {
+            setError("Passcode must be 6 digits")
+            setIsLoading(false)
+            return
+          }
+          if (passcode === oldPasscode) {
+            setError("New passcode must be different")
+            setIsLoading(false)
+            return
+          }
+          setStep("confirm")
+          setIsLoading(false)
+          return
+        } else if (step === "confirm") {
+          if (confirmPasscode !== passcode) {
+            setError("Passcodes do not match")
+            setIsLoading(false)
+            return
+          }
+          const result = await onSubmit(passcode, oldPasscode)
+          if (result.success) {
+            onOpenChange(false)
+          } else {
+            setError(result.message || "Failed to change passcode")
+          }
+        }
+      } else {
+        // Verify mode - single passcode entry
+        if (passcode.length !== 6) {
+          setError("Passcode must be 6 digits")
+          setIsLoading(false)
+          return
+        }
+        const result = await onSubmit(passcode)
+        if (result.success) {
+          onOpenChange(false)
+        } else {
+          if (result.locked) {
+            setError(result.message || "Too many failed attempts")
+          } else {
+            setError(result.message || "Incorrect passcode")
+            // Clear passcode on error for retry
+            setPasscode("")
+          }
+        }
+      }
+    } catch (error) {
+      setError("An error occurred. Please try again.")
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const handleBack = () => {
+    setError("")
+    if (step === "confirm") {
+      setConfirmPasscode("")
+      setStep("new")
+    } else if (step === "new" && mode === "change") {
+      setPasscode("")
+      setStep("old")
+    }
+  }
+
+  const getTitle = () => {
+    if (title) return title
+    if (mode === "setup") {
+      return step === "new" ? "Set Transaction Passcode" : "Confirm Passcode"
+    }
+    if (mode === "change") {
+      if (step === "old") return "Enter Current Passcode"
+      if (step === "new") return "Enter New Passcode"
+      return "Confirm New Passcode"
+    }
+    return "Enter Passcode"
+  }
+
+  const getDescription = () => {
+    if (description && step === (mode === "verify" ? "single" : "new")) {
+      return description
+    }
+    if (mode === "setup") {
+      return step === "new"
+        ? "Set up a 6-digit passcode for secure transactions"
+        : "Re-enter your passcode to confirm"
+    }
+    if (mode === "change") {
+      if (step === "old") return "Enter your current passcode"
+      if (step === "new") return "Enter your new 6-digit passcode"
+      return "Re-enter your new passcode to confirm"
+    }
+    return "Enter your 6-digit transaction passcode"
+  }
+
+  const getCurrentValue = () => {
+    if (step === "old") return oldPasscode
+    if (step === "confirm") return confirmPasscode
+    return passcode
+  }
+
+  const handleValueChange = (value: string) => {
+    setError("")
+    if (step === "old") {
+      setOldPasscode(value)
+    } else if (step === "confirm") {
+      setConfirmPasscode(value)
+    } else {
+      setPasscode(value)
+    }
+  }
+
+  const canSubmit = () => {
+    const currentValue = getCurrentValue()
+    return currentValue.length === 6 && !isLoading
+  }
+
+  const showBackButton = () => {
+    return (step === "confirm" || (step === "new" && mode === "change")) && !isLoading
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Lock className="h-5 w-5" />
+            {getTitle()}
+          </DialogTitle>
+          <DialogDescription>{getDescription()}</DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col items-center gap-6 py-4">
+          <InputOTP
+            maxLength={6}
+            value={getCurrentValue()}
+            onChange={handleValueChange}
+            pattern="^[0-9]+$"
+            disabled={isLoading}
+            onComplete={() => {
+              // Auto-submit when 6 digits are entered in verify mode
+              if (mode === "verify" && step === "single") {
+                setTimeout(handleSubmit, 100)
+              }
+            }}
+          >
+            <InputOTPGroup>
+              <InputOTPSlot index={0} />
+              <InputOTPSlot index={1} />
+              <InputOTPSlot index={2} />
+              <InputOTPSlot index={3} />
+              <InputOTPSlot index={4} />
+              <InputOTPSlot index={5} />
+            </InputOTPGroup>
+          </InputOTP>
+
+          {error && (
+            <div className="flex items-center gap-2 text-destructive text-sm">
+              <AlertCircle className="h-4 w-4" />
+              <span>{error}</span>
+            </div>
+          )}
+        </div>
+
+        <div className="flex gap-2 justify-end">
+          {showBackButton() && (
+            <Button variant="outline" onClick={handleBack} disabled={isLoading}>
+              Back
+            </Button>
+          )}
+          <Button onClick={handleSubmit} disabled={!canSubmit()}>
+            {isLoading ? "Processing..." : step === "confirm" ? "Confirm" : step === "old" ? "Next" : step === "new" ? "Continue" : "Submit"}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/fraudwallet/frontend/src/components/profile-tab.tsx
+++ b/fraudwallet/frontend/src/components/profile-tab.tsx
@@ -6,8 +6,9 @@ import { Card } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label";
-import { Settings, Bell, Shield, HelpCircle, LogOut, ChevronRight, UserX, Copy, QrCode } from "lucide-react"
+import { Settings, Bell, Shield, HelpCircle, LogOut, ChevronRight, UserX, Copy, QrCode, Lock } from "lucide-react"
 import { QRCodeCanvas } from "qrcode.react"
+import { PasscodeDialog } from "@/components/passcode-dialog"
 
 export function ProfileTab() {
   const router = useRouter()
@@ -38,6 +39,13 @@ export function ProfileTab() {
   const [showDisableForm, setShowDisableForm] = useState(false)
   const [disableCodeSent, setDisableCodeSent] = useState(false)
 
+  // Passcode states
+  const [hasPasscode, setHasPasscode] = useState(false)
+  const [showPasscodeDialog, setShowPasscodeDialog] = useState(false)
+  const [passcodeMode, setPasscodeMode] = useState<"setup" | "change" | "verify">("setup")
+  const [setupPassword, setSetupPassword] = useState("")
+  const [showPasswordPrompt, setShowPasswordPrompt] = useState(false)
+
   // Load user data from localStorage
   useEffect(() => {
     const storedUser = localStorage.getItem("user")
@@ -46,6 +54,28 @@ export function ProfileTab() {
       setUser(userData)
       setFullName(userData.fullName || "")
     }
+  }, [])
+
+  // Fetch passcode status
+  useEffect(() => {
+    const fetchPasscodeStatus = async () => {
+      try {
+        const token = localStorage.getItem("token")
+        const response = await fetch("http://localhost:8080/api/user/passcode/status", {
+          headers: {
+            "Authorization": `Bearer ${token}`
+          }
+        })
+        const data = await response.json()
+        if (data.success) {
+          setHasPasscode(data.hasPasscode)
+        }
+      } catch (error) {
+        console.error("Failed to fetch passcode status:", error)
+      }
+    }
+
+    fetchPasscodeStatus()
   }, [])
 
   // Get user initials for avatar
@@ -461,6 +491,85 @@ export function ProfileTab() {
     } finally {
       setLoading(false)
     }
+  }
+
+  // Passcode handlers
+  const handleSetupPasscode = () => {
+    setPasscodeMode("setup")
+    setShowPasswordPrompt(true)
+  }
+
+  const handleChangePasscode = () => {
+    setPasscodeMode("change")
+    setShowPasscodeDialog(true)
+  }
+
+  const handlePasscodeSubmit = async (passcode: string, oldPasscode?: string) => {
+    try {
+      const token = localStorage.getItem("token")
+
+      if (passcodeMode === "setup") {
+        // Setup requires password verification
+        const response = await fetch("http://localhost:8080/api/user/passcode/set", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "Authorization": `Bearer ${token}`
+          },
+          body: JSON.stringify({
+            passcode,
+            currentPassword: setupPassword
+          })
+        })
+
+        const data = await response.json()
+
+        if (data.success) {
+          setHasPasscode(true)
+          setSuccessMessage("Transaction passcode set successfully!")
+          return { success: true }
+        } else {
+          return { success: false, message: data.message }
+        }
+      } else if (passcodeMode === "change") {
+        // Change requires old and new passcode
+        const response = await fetch("http://localhost:8080/api/user/passcode/change", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "Authorization": `Bearer ${token}`
+          },
+          body: JSON.stringify({
+            oldPasscode,
+            newPasscode: passcode
+          })
+        })
+
+        const data = await response.json()
+
+        if (data.success) {
+          setSuccessMessage("Transaction passcode changed successfully!")
+          return { success: true }
+        } else {
+          return { success: false, message: data.message, locked: response.status === 429 }
+        }
+      }
+
+      return { success: false, message: "Invalid mode" }
+    } catch (error) {
+      console.error("Passcode operation error:", error)
+      return { success: false, message: "Failed to process passcode" }
+    }
+  }
+
+  const handlePasswordSubmit = () => {
+    if (!setupPassword) {
+      setError("Password is required")
+      return
+    }
+    setShowPasswordPrompt(false)
+    setShowPasscodeDialog(true)
+    setError("")
   }
 
   const menuItems = [
@@ -998,6 +1107,51 @@ export function ProfileTab() {
                 </>
               )}
 
+              {/* Transaction Passcode Section */}
+              <div className="border-t border-border" />
+
+              <div className="space-y-4">
+                <div>
+                  <h4 className="font-semibold flex items-center gap-2">
+                    <Lock className="h-4 w-4" />
+                    Transaction Passcode
+                  </h4>
+                  <p className="text-sm text-muted-foreground mt-1">
+                    Secure your transactions with a 6-digit passcode
+                  </p>
+                </div>
+
+                <div className="flex items-center justify-between rounded-lg border p-4">
+                  <div>
+                    <p className="font-medium">
+                      Passcode is {hasPasscode ? "Set" : "Not Set"}
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      {hasPasscode
+                        ? "Required for top-up, transfer, and split payments"
+                        : "Set up a passcode to secure your transactions"}
+                    </p>
+                  </div>
+                </div>
+
+                {hasPasscode ? (
+                  <Button
+                    variant="outline"
+                    onClick={handleChangePasscode}
+                    className="w-full"
+                  >
+                    Change Passcode
+                  </Button>
+                ) : (
+                  <Button
+                    onClick={handleSetupPasscode}
+                    className="w-full"
+                  >
+                    Set Up Passcode
+                  </Button>
+                )}
+              </div>
+
               {/* Close Button */}
               <Button
                 variant="outline"
@@ -1180,6 +1334,72 @@ export function ProfileTab() {
           </div>
         </div>
       )}
+
+      {/* Password Prompt for Passcode Setup */}
+      {showPasswordPrompt && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+          <div className="w-full max-w-md rounded-lg bg-background p-6 shadow-xl">
+            <h3 className="mb-4 text-xl font-bold">Verify Your Password</h3>
+
+            {error && (
+              <div className="mb-4 rounded-lg bg-destructive/10 p-3 text-sm text-destructive">
+                {error}
+              </div>
+            )}
+
+            <p className="mb-4 text-sm text-muted-foreground">
+              Enter your password to set up your transaction passcode
+            </p>
+
+            <div className="space-y-4">
+              <div>
+                <Label htmlFor="setup-password">Password</Label>
+                <Input
+                  id="setup-password"
+                  type="password"
+                  value={setupPassword}
+                  onChange={(e) => setSetupPassword(e.target.value)}
+                  placeholder="Enter your password"
+                />
+              </div>
+
+              <div className="flex gap-2">
+                <Button
+                  onClick={handlePasswordSubmit}
+                  disabled={!setupPassword}
+                  className="flex-1"
+                >
+                  Continue
+                </Button>
+                <Button
+                  variant="outline"
+                  onClick={() => {
+                    setShowPasswordPrompt(false)
+                    setSetupPassword("")
+                    setError("")
+                  }}
+                  className="flex-1"
+                >
+                  Cancel
+                </Button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Passcode Dialog */}
+      <PasscodeDialog
+        open={showPasscodeDialog}
+        onOpenChange={(open) => {
+          setShowPasscodeDialog(open)
+          if (!open) {
+            setSetupPassword("")
+          }
+        }}
+        mode={passcodeMode}
+        onSubmit={handlePasscodeSubmit}
+      />
 
       {/* QR Code Modal */}
       {showQRModal && user?.accountId && (

--- a/fraudwallet/frontend/src/components/ui/dialog.tsx
+++ b/fraudwallet/frontend/src/components/ui/dialog.tsx
@@ -1,0 +1,122 @@
+"use client"
+
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { X } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Dialog = DialogPrimitive.Root
+
+const DialogTrigger = DialogPrimitive.Trigger
+
+const DialogPortal = DialogPrimitive.Portal
+
+const DialogClose = DialogPrimitive.Close
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/80",
+      className
+    )}
+    {...props}
+  />
+))
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] bg-background fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border p-6 shadow-lg duration-200 sm:rounded-lg",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute right-4 top-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:pointer-events-none">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+))
+DialogContent.displayName = DialogPrimitive.Content.displayName
+
+const DialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-1.5 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+)
+DialogHeader.displayName = "DialogHeader"
+
+const DialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+)
+DialogFooter.displayName = "DialogFooter"
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn(
+      "text-lg font-semibold leading-none tracking-tight",
+      className
+    )}
+    {...props}
+  />
+))
+DialogTitle.displayName = DialogPrimitive.Title.displayName
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-muted-foreground text-sm", className)}
+    {...props}
+  />
+))
+DialogDescription.displayName = DialogPrimitive.Description.displayName
+
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogClose,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+}

--- a/fraudwallet/frontend/src/components/ui/input-otp.tsx
+++ b/fraudwallet/frontend/src/components/ui/input-otp.tsx
@@ -1,0 +1,71 @@
+"use client"
+
+import * as React from "react"
+import { OTPInput, OTPInputContext } from "input-otp"
+import { Dot } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const InputOTP = React.forwardRef<
+  React.ElementRef<typeof OTPInput>,
+  React.ComponentPropsWithoutRef<typeof OTPInput>
+>(({ className, containerClassName, ...props }, ref) => (
+  <OTPInput
+    ref={ref}
+    containerClassName={cn(
+      "flex items-center gap-2 has-[:disabled]:opacity-50",
+      containerClassName
+    )}
+    className={cn("disabled:cursor-not-allowed", className)}
+    {...props}
+  />
+))
+InputOTP.displayName = "InputOTP"
+
+const InputOTPGroup = React.forwardRef<
+  React.ElementRef<"div">,
+  React.ComponentPropsWithoutRef<"div">
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("flex items-center", className)} {...props} />
+))
+InputOTPGroup.displayName = "InputOTPGroup"
+
+const InputOTPSlot = React.forwardRef<
+  React.ElementRef<"div">,
+  React.ComponentPropsWithoutRef<"div"> & { index: number }
+>(({ index, className, ...props }, ref) => {
+  const inputOTPContext = React.useContext(OTPInputContext)
+  const { char, hasFakeCaret, isActive } = inputOTPContext.slots[index]
+
+  return (
+    <div
+      ref={ref}
+      className={cn(
+        "border-input relative flex h-10 w-10 items-center justify-center border-y border-r text-sm transition-all first:rounded-l-md first:border-l last:rounded-r-md",
+        isActive && "ring-ring/50 ring-[3px] z-10 border-ring",
+        className
+      )}
+      {...props}
+    >
+      {char}
+      {hasFakeCaret && (
+        <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+          <div className="animate-caret-blink bg-foreground h-4 w-px duration-1000" />
+        </div>
+      )}
+    </div>
+  )
+})
+InputOTPSlot.displayName = "InputOTPSlot"
+
+const InputOTPSeparator = React.forwardRef<
+  React.ElementRef<"div">,
+  React.ComponentPropsWithoutRef<"div">
+>(({ ...props }, ref) => (
+  <div ref={ref} role="separator" {...props}>
+    <Dot />
+  </div>
+))
+InputOTPSeparator.displayName = "InputOTPSeparator"
+
+export { InputOTP, InputOTPGroup, InputOTPSlot, InputOTPSeparator }


### PR DESCRIPTION
Implement a 6-digit numeric passcode system to enhance security for all transactions:

Backend Changes:
- Add transaction_passcode, passcode_attempts, and passcode_locked_until columns to users table
- Create passcode service with bcrypt hashing, rate limiting (3 attempts), and 15-minute lockout
- Add passcode API endpoints for set, verify, and change operations
- Update sendMoney, createPaymentIntent, and payMyShare endpoints to require passcode verification
- Enforce passcode setup before allowing transactions

Frontend Changes:
- Create reusable PasscodeDialog component with input-otp for secure 6-digit entry
- Add UI dialog component using Radix UI for modal interactions
- Integrate passcode management in profile security settings
- Add passcode verification to send money flow with setup prompts
- Add passcode verification to top-up flow with setup prompts
- Add passcode verification to split bill payment flow with setup prompts
- Force users to set up passcode before first transaction

Security Features:
- Bcrypt password hashing for passcode storage
- Rate limiting with 3 attempts before 15-minute lockout
- Password verification required when setting up passcode
- Old passcode required when changing passcode
- Automatic lockout reset after timeout period