### PR TITLE
Add IP-based timezone detection with badge display

### DIFF
--- a/fraudwallet/backend/src/server.js
+++ b/fraudwallet/backend/src/server.js
@@ -65,6 +65,9 @@ app.get('/api/user/passcode/status', verifyToken, passcodeAPI.getUserPasscodeSta
 // Payment routes (protected)
 app.post('/api/payment/lookup-recipient', verifyToken, user.lookupRecipient);
 
+// Timezone route (protected)
+app.get('/api/user/timezone', verifyToken, user.getUserTimezone);
+
 // Split payment routes (protected)
 const splitpay = require('./splitpay');
 app.post('/api/splitpay/create', verifyToken, splitpay.createSplitPayment);

--- a/fraudwallet/frontend/src/app/page.tsx
+++ b/fraudwallet/frontend/src/app/page.tsx
@@ -8,6 +8,7 @@ import { ProfileTab } from "@/components/profile-tab"
 import { FraudDashboardTab } from "@/components/fraud-dashboard-tab"
 import { Home, Send, Users, User, Shield } from "lucide-react"
 import { useAuth } from "@/hooks/useAuth"
+import { TimezoneProvider } from "@/contexts/TimezoneContext"
 
 export default function WalletApp() {
   const [activeTab, setActiveTab] = useState<"dashboard" | "payment" | "splitpay" | "fraud" | "profile">("dashboard")
@@ -32,6 +33,7 @@ export default function WalletApp() {
   }
 
   return (
+    <TimezoneProvider>
     <div className="flex min-h-screen items-center justify-center bg-muted p-4">
       <div className="w-full max-w-md">
         {/* Mobile App Container */}
@@ -118,5 +120,6 @@ export default function WalletApp() {
         </div>
       </div>
     </div>
+    </TimezoneProvider>
   )
 }

--- a/fraudwallet/frontend/src/components/TimeDisplay.tsx
+++ b/fraudwallet/frontend/src/components/TimeDisplay.tsx
@@ -1,0 +1,88 @@
+"use client"
+
+import React from 'react'
+import { useTimezone } from '@/contexts/TimezoneContext'
+import { formatWithTimezone } from '@/utils/timezone'
+
+interface TimeDisplayProps {
+  utcDate: string
+  format?: 'full' | 'date' | 'time' | 'relative'
+  showBadge?: boolean
+  className?: string
+}
+
+/**
+ * TimeDisplay Component
+ * Displays timestamps in user's local timezone with UTC offset badge
+ */
+export const TimeDisplay: React.FC<TimeDisplayProps> = ({
+  utcDate,
+  format = 'full',
+  showBadge = true,
+  className = ''
+}) => {
+  const { offsetHours, offsetLabel, loading } = useTimezone()
+
+  if (loading) {
+    return <span className={className}>Loading...</span>
+  }
+
+  if (!utcDate) {
+    return <span className={className}>N/A</span>
+  }
+
+  const formattedTime = formatWithTimezone(utcDate, offsetHours, offsetLabel, format)
+
+  return (
+    <span className={`inline-flex items-center gap-2 ${className}`}>
+      <span>{formattedTime}</span>
+      {showBadge && (
+        <span className="inline-flex items-center rounded-md bg-blue-50 dark:bg-blue-900/20 px-2 py-0.5 text-xs font-medium text-blue-700 dark:text-blue-400 ring-1 ring-inset ring-blue-700/10 dark:ring-blue-400/30">
+          {offsetLabel}
+        </span>
+      )}
+    </span>
+  )
+}
+
+/**
+ * Compact version without badge (for tight spaces)
+ */
+export const TimeDisplayCompact: React.FC<Omit<TimeDisplayProps, 'showBadge'>> = (props) => {
+  return <TimeDisplay {...props} showBadge={false} />
+}
+
+/**
+ * Time display with custom badge position
+ */
+export const TimeDisplayWithTooltip: React.FC<TimeDisplayProps> = ({
+  utcDate,
+  format = 'full',
+  className = ''
+}) => {
+  const { offsetHours, offsetLabel, loading, timezone } = useTimezone()
+
+  if (loading) {
+    return <span className={className}>Loading...</span>
+  }
+
+  if (!utcDate) {
+    return <span className={className}>N/A</span>
+  }
+
+  const formattedTime = formatWithTimezone(utcDate, offsetHours, offsetLabel, format)
+
+  return (
+    <span className={`inline-flex items-center gap-2 ${className}`}>
+      <span>{formattedTime}</span>
+      <span
+        className="inline-flex items-center rounded-md bg-blue-50 dark:bg-blue-900/20 px-2 py-0.5 text-xs font-medium text-blue-700 dark:text-blue-400 ring-1 ring-inset ring-blue-700/10 dark:ring-blue-400/30 cursor-help"
+        title={`${timezone} - ${offsetLabel}`}
+      >
+        {offsetLabel}
+      </span>
+    </span>
+  )
+}
+
+export default TimeDisplay

--- a/fraudwallet/frontend/src/components/dashboard-tab.tsx
+++ b/fraudwallet/frontend/src/components/dashboard-tab.tsx
@@ -13,6 +13,7 @@ import { usePullToRefresh } from "@/hooks/usePullToRefresh"
 import { PullToRefreshIndicator } from "@/components/ui/pull-to-refresh-indicator"
 import { PasscodeDialog } from "@/components/passcode-dialog"
 import { useRouter } from "next/navigation"
+import { TimeDisplay } from "@/components/TimeDisplay"
 
 // Initialize Stripe with publishable key
 const stripePromise = loadStripe(process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY || "")
@@ -398,8 +399,13 @@ export function DashboardTab() {
                   </div>
                   <div>
                     <p className="font-medium">{transaction.description || "Transaction"}</p>
-                    <p className="text-xs text-muted-foreground">{formatDate(transaction.created_at)}</p>
-                    <span className={`text-xs px-2 py-0.5 rounded-full ${
+                    <TimeDisplay
+                      utcDate={transaction.created_at}
+                      format="relative"
+                      showBadge={true}
+                      className="text-xs text-muted-foreground"
+                    />
+                    <span className={`text-xs px-2 py-0.5 rounded-full ml-2 ${
                       transaction.status === 'completed' ? 'bg-green-500/10 text-green-600' :
                       transaction.status === 'pending' ? 'bg-yellow-500/10 text-yellow-600' :
                       'bg-red-500/10 text-red-600'

--- a/fraudwallet/frontend/src/components/splitpay-tab.tsx
+++ b/fraudwallet/frontend/src/components/splitpay-tab.tsx
@@ -10,6 +10,7 @@ import { usePullToRefresh } from "@/hooks/usePullToRefresh"
 import { PullToRefreshIndicator } from "@/components/ui/pull-to-refresh-indicator"
 import { PasscodeDialog } from "@/components/passcode-dialog"
 import { useRouter } from "next/navigation"
+import { TimeDisplay } from "@/components/TimeDisplay"
 
 export function SplitPayTab() {
   const router = useRouter()
@@ -509,8 +510,12 @@ export function SplitPayTab() {
                   </div>
                   <div className="flex items-center gap-2 mt-1 text-xs text-muted-foreground">
                     <Calendar className="h-3 w-3" />
-                    <span>{formatDateShort(split.created_at)}</span>
-                    <span className="text-xs">• {formatDateTime(split.created_at)}</span>
+                    <TimeDisplay
+                      utcDate={split.created_at}
+                      format="full"
+                      showBadge={true}
+                      className="text-xs"
+                    />
                   </div>
                 </div>
                 <div className="text-right">
@@ -588,13 +593,25 @@ export function SplitPayTab() {
                         {participant.responded_at && (
                           <div className="flex items-center gap-1">
                             <Check className="h-3 w-3" />
-                            <span>Responded: {formatDateTime(participant.responded_at)}</span>
+                            <span>Responded: </span>
+                            <TimeDisplay
+                              utcDate={participant.responded_at}
+                              format="full"
+                              showBadge={true}
+                              className="text-xs"
+                            />
                           </div>
                         )}
                         {participant.paid === 1 && participant.paid_at && (
                           <div className="flex items-center gap-1">
                             <DollarSign className="h-3 w-3" />
-                            <span>Paid: {formatDateTime(participant.paid_at)}</span>
+                            <span>Paid: </span>
+                            <TimeDisplay
+                              utcDate={participant.paid_at}
+                              format="full"
+                              showBadge={true}
+                              className="text-xs"
+                            />
                           </div>
                         )}
                         {participant.status === 'pending' && (

--- a/fraudwallet/frontend/src/contexts/TimezoneContext.tsx
+++ b/fraudwallet/frontend/src/contexts/TimezoneContext.tsx
@@ -1,0 +1,77 @@
+"use client"
+
+import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react'
+import { TimezoneInfo, fetchUserTimezone, getDefaultTimezone } from '@/utils/timezone'
+
+interface TimezoneContextType {
+  timezone: string
+  offsetHours: number
+  offsetLabel: string
+  loading: boolean
+  refreshTimezone: () => Promise<void>
+}
+
+const TimezoneContext = createContext<TimezoneContextType | undefined>(undefined)
+
+export const useTimezone = () => {
+  const context = useContext(TimezoneContext)
+  if (!context) {
+    throw new Error('useTimezone must be used within TimezoneProvider')
+  }
+  return context
+}
+
+interface TimezoneProviderProps {
+  children: ReactNode
+}
+
+export const TimezoneProvider: React.FC<TimezoneProviderProps> = ({ children }) => {
+  const [timezoneInfo, setTimezoneInfo] = useState<TimezoneInfo>(getDefaultTimezone())
+  const [loading, setLoading] = useState(true)
+
+  const loadTimezone = async () => {
+    try {
+      setLoading(true)
+      const token = localStorage.getItem('token')
+
+      if (!token) {
+        // Not logged in, use default timezone
+        setTimezoneInfo(getDefaultTimezone())
+        return
+      }
+
+      const info = await fetchUserTimezone(token)
+      setTimezoneInfo(info)
+
+      console.log(`🌍 Timezone loaded: ${info.timezone} (${info.offsetLabel})`)
+    } catch (error) {
+      console.error('Failed to load timezone:', error)
+      setTimezoneInfo(getDefaultTimezone())
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  // Load timezone on mount
+  useEffect(() => {
+    loadTimezone()
+  }, [])
+
+  const refreshTimezone = async () => {
+    await loadTimezone()
+  }
+
+  const value: TimezoneContextType = {
+    timezone: timezoneInfo.timezone,
+    offsetHours: timezoneInfo.offsetHours,
+    offsetLabel: timezoneInfo.offsetLabel,
+    loading,
+    refreshTimezone
+  }
+
+  return (
+    <TimezoneContext.Provider value={value}>
+      {children}
+    </TimezoneContext.Provider>
+  )
+}

--- a/fraudwallet/frontend/src/utils/timezone.ts
+++ b/fraudwallet/frontend/src/utils/timezone.ts
@@ -1,0 +1,157 @@
+// Timezone utility functions for converting UTC timestamps to local time
+
+export interface TimezoneInfo {
+  timezone: string
+  offset: string
+  offsetHours: number
+  offsetLabel: string
+  country: string
+  city: string
+}
+
+/**
+ * Convert UTC timestamp to local time with timezone offset
+ * @param utcDate - UTC timestamp string from database
+ * @param offsetHours - Timezone offset in hours (e.g., 8 for UTC+8)
+ * @returns Date object in local timezone
+ */
+export const convertToLocalTime = (utcDate: string, offsetHours: number): Date => {
+  if (!utcDate) return new Date()
+
+  const date = new Date(utcDate)
+  // Add offset to convert from UTC to local time
+  const localDate = new Date(date.getTime() + (offsetHours * 60 * 60 * 1000))
+  return localDate
+}
+
+/**
+ * Format date with timezone badge
+ * @param utcDate - UTC timestamp string
+ * @param offsetHours - Timezone offset in hours
+ * @param offsetLabel - Timezone label (e.g., "UTC+8")
+ * @param format - Format type: "full", "date", "time", or "relative"
+ * @returns Formatted string with timezone badge
+ */
+export const formatWithTimezone = (
+  utcDate: string,
+  offsetHours: number,
+  offsetLabel: string,
+  format: 'full' | 'date' | 'time' | 'relative' = 'full'
+): string => {
+  if (!utcDate) return 'N/A'
+
+  const localDate = convertToLocalTime(utcDate, offsetHours)
+
+  let formattedDate = ''
+
+  switch (format) {
+    case 'full':
+      // Example: "Dec 16, 2023 14:30"
+      formattedDate = localDate.toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: false
+      })
+      break
+
+    case 'date':
+      // Example: "Dec 16, 2023"
+      formattedDate = localDate.toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric'
+      })
+      break
+
+    case 'time':
+      // Example: "14:30"
+      formattedDate = localDate.toLocaleTimeString('en-US', {
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: false
+      })
+      break
+
+    case 'relative':
+      // Example: "2 hours ago"
+      formattedDate = getRelativeTime(localDate)
+      break
+  }
+
+  return formattedDate
+}
+
+/**
+ * Get relative time string (e.g., "2 hours ago", "3 days ago")
+ * @param date - Date object
+ * @returns Relative time string
+ */
+export const getRelativeTime = (date: Date): string => {
+  const now = new Date()
+  const diffMs = now.getTime() - date.getTime()
+  const diffSeconds = Math.floor(diffMs / 1000)
+  const diffMinutes = Math.floor(diffSeconds / 60)
+  const diffHours = Math.floor(diffMinutes / 60)
+  const diffDays = Math.floor(diffHours / 24)
+  const diffMonths = Math.floor(diffDays / 30)
+  const diffYears = Math.floor(diffDays / 365)
+
+  if (diffSeconds < 60) return 'Just now'
+  if (diffMinutes < 60) return `${diffMinutes} minute${diffMinutes > 1 ? 's' : ''} ago`
+  if (diffHours < 24) return `${diffHours} hour${diffHours > 1 ? 's' : ''} ago`
+  if (diffDays < 30) return `${diffDays} day${diffDays > 1 ? 's' : ''} ago`
+  if (diffMonths < 12) return `${diffMonths} month${diffMonths > 1 ? 's' : ''} ago`
+  return `${diffYears} year${diffYears > 1 ? 's' : ''} ago`
+}
+
+/**
+ * Fetch user's timezone from backend based on IP
+ * @param token - Auth token
+ * @returns Timezone information
+ */
+export const fetchUserTimezone = async (token: string): Promise<TimezoneInfo> => {
+  try {
+    const response = await fetch('http://localhost:8080/api/user/timezone', {
+      headers: {
+        'Authorization': `Bearer ${token}`
+      }
+    })
+
+    const data = await response.json()
+
+    if (data.success) {
+      return {
+        timezone: data.timezone,
+        offset: data.offset,
+        offsetHours: data.offsetHours,
+        offsetLabel: data.offsetLabel,
+        country: data.country,
+        city: data.city
+      }
+    }
+
+    // Default to UTC+8 if fetch fails
+    return getDefaultTimezone()
+  } catch (error) {
+    console.error('Failed to fetch timezone:', error)
+    return getDefaultTimezone()
+  }
+}
+
+/**
+ * Get default timezone (UTC+8 - Malaysia)
+ * @returns Default timezone info
+ */
+export const getDefaultTimezone = (): TimezoneInfo => {
+  return {
+    timezone: 'Asia/Kuala_Lumpur',
+    offset: '+08:00',
+    offsetHours: 8,
+    offsetLabel: 'UTC+8',
+    country: 'Local',
+    city: 'Local'
+  }
+}


### PR DESCRIPTION
Implemented automatic timezone conversion for all timestamps:
- Backend: IP geolocation endpoint using geoip-lite (defaults to UTC+8 for localhost)
- Frontend: React Context for timezone state management
- Components: Reusable TimeDisplay component with badge-style UTC offset indicator
- Updated transaction history and split payment timestamps to show user's local time
- Displays UTC offset badge (e.g., "UTC+8") for traveling users