### PR TITLE
Update timezone system with click-to-toggle functionality

### DIFF
--- a/fraudwallet/frontend/src/components/TimeDisplay.tsx
+++ b/fraudwallet/frontend/src/components/TimeDisplay.tsx
@@ -14,6 +14,7 @@ interface TimeDisplayProps {
 /**
  * TimeDisplay Component
  * Displays timestamps in user's local timezone with UTC offset badge
+ * Click badge to toggle between UTC+8 and UTC+0
  */
 export const TimeDisplay: React.FC<TimeDisplayProps> = ({
   utcDate,
@@ -21,11 +22,7 @@ export const TimeDisplay: React.FC<TimeDisplayProps> = ({
   showBadge = true,
   className = ''
 }) => {
-  const { offsetHours, offsetLabel, loading } = useTimezone()
-
-  if (loading) {
-    return <span className={className}>Loading...</span>
-  }
+  const { offsetHours, offsetLabel, toggleTimezone } = useTimezone()
 
   if (!utcDate) {
     return <span className={className}>N/A</span>
@@ -37,7 +34,11 @@ export const TimeDisplay: React.FC<TimeDisplayProps> = ({
     <span className={`inline-flex items-center gap-2 ${className}`}>
       <span>{formattedTime}</span>
       {showBadge && (
-        <span className="inline-flex items-center rounded-md bg-blue-50 dark:bg-blue-900/20 px-2 py-0.5 text-xs font-medium text-blue-700 dark:text-blue-400 ring-1 ring-inset ring-blue-700/10 dark:ring-blue-400/30">
+        <span
+          onClick={toggleTimezone}
+          className="inline-flex items-center rounded-md bg-blue-50 dark:bg-blue-900/20 px-2 py-0.5 text-xs font-medium text-blue-700 dark:text-blue-400 ring-1 ring-inset ring-blue-700/10 dark:ring-blue-400/30 cursor-pointer hover:bg-blue-100 dark:hover:bg-blue-900/30 transition-colors"
+          title="Click to toggle timezone"
+        >
           {offsetLabel}
         </span>
       )}
@@ -60,11 +61,7 @@ export const TimeDisplayWithTooltip: React.FC<TimeDisplayProps> = ({
   format = 'full',
   className = ''
 }) => {
-  const { offsetHours, offsetLabel, loading, timezone } = useTimezone()
-
-  if (loading) {
-    return <span className={className}>Loading...</span>
-  }
+  const { offsetHours, offsetLabel, toggleTimezone } = useTimezone()
 
   if (!utcDate) {
     return <span className={className}>N/A</span>
@@ -76,8 +73,9 @@ export const TimeDisplayWithTooltip: React.FC<TimeDisplayProps> = ({
     <span className={`inline-flex items-center gap-2 ${className}`}>
       <span>{formattedTime}</span>
       <span
-        className="inline-flex items-center rounded-md bg-blue-50 dark:bg-blue-900/20 px-2 py-0.5 text-xs font-medium text-blue-700 dark:text-blue-400 ring-1 ring-inset ring-blue-700/10 dark:ring-blue-400/30 cursor-help"
-        title={`${timezone} - ${offsetLabel}`}
+        onClick={toggleTimezone}
+        className="inline-flex items-center rounded-md bg-blue-50 dark:bg-blue-900/20 px-2 py-0.5 text-xs font-medium text-blue-700 dark:text-blue-400 ring-1 ring-inset ring-blue-700/10 dark:ring-blue-400/30 cursor-pointer hover:bg-blue-100 dark:hover:bg-blue-900/30 transition-colors"
+        title={`Click to toggle timezone - ${offsetLabel}`}
       >
         {offsetLabel}
       </span>

--- a/fraudwallet/frontend/src/components/dashboard-tab.tsx
+++ b/fraudwallet/frontend/src/components/dashboard-tab.tsx
@@ -401,7 +401,7 @@ export function DashboardTab() {
                     <p className="font-medium">{transaction.description || "Transaction"}</p>
                     <TimeDisplay
                       utcDate={transaction.created_at}
-                      format="relative"
+                      format="full"
                       showBadge={true}
                       className="text-xs text-muted-foreground"
                     />

--- a/fraudwallet/frontend/src/components/fraud-dashboard-tab.tsx
+++ b/fraudwallet/frontend/src/components/fraud-dashboard-tab.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button"
 import { AlertTriangle, Shield, Activity, TrendingUp, Users, AlertCircle, CheckCircle, XCircle, Heart } from "lucide-react"
 import { usePullToRefresh } from "@/hooks/usePullToRefresh"
 import { PullToRefreshIndicator } from "@/components/ui/pull-to-refresh-indicator"
+import { TimeDisplay } from "@/components/TimeDisplay"
 
 interface FraudLog {
   id: number
@@ -479,7 +480,12 @@ export function FraudDashboardTab() {
                   </div>
                   <div className="mt-2 flex justify-between text-xs text-muted-foreground">
                     <span>{user.blocked_count} blocked • {user.review_count} reviewed</span>
-                    <span>{formatDate(user.last_flagged)}</span>
+                    <TimeDisplay
+                      utcDate={user.last_flagged}
+                      format="full"
+                      showBadge={true}
+                      className="text-xs"
+                    />
                   </div>
                 </Card>
               ))}
@@ -515,7 +521,12 @@ export function FraudDashboardTab() {
                     <span className="text-sm font-bold">RM {log.amount.toFixed(2)}</span>
                   </div>
                   <div className="flex items-center justify-between text-xs">
-                    <span className="text-muted-foreground">{formatDate(log.created_at)}</span>
+                    <TimeDisplay
+                      utcDate={log.created_at}
+                      format="full"
+                      showBadge={true}
+                      className="text-xs text-muted-foreground"
+                    />
                     <span className={`px-2 py-0.5 rounded-full border ${getRiskLevelColor(log.risk_level)}`}>
                       Risk Score: {log.risk_score}
                     </span>


### PR DESCRIPTION
Changes to timezone implementation:
- TimezoneContext: Simplified to default UTC+8, toggle to UTC+0 on click
- TimeDisplay: Made badge clickable with hover effect and toggle functionality
- Removed IP-based timezone detection in favor of manual toggle
- Changed all timestamp formats from "relative" to "full" date/time display
- Applied timezone display to fraud dashboard (admin page)
- User preference saved to localStorage and persists across sessions