### PR TITLE
Fix missing recipient data in fraud detection logs

### DIFF
--- a/fraudwallet/backend/src/wallet.js
+++ b/fraudwallet/backend/src/wallet.js
@@ -435,11 +435,20 @@ const sendMoney = async (req, res) => {
     }
 
     // Check sender exists and has sufficient balance
-    const sender = db.prepare('SELECT id, wallet_balance, full_name, created_at FROM users WHERE id = ?').get(senderId);
+    const sender = db.prepare('SELECT id, wallet_balance, full_name, account_id, created_at FROM users WHERE id = ?').get(senderId);
     if (!sender) {
       return res.status(404).json({
         success: false,
         message: 'Sender not found'
+      });
+    }
+
+    // Check recipient exists
+    const recipient = db.prepare('SELECT id, full_name, account_id FROM users WHERE id = ?').get(recipientId);
+    if (!recipient) {
+      return res.status(404).json({
+        success: false,
+        message: 'Recipient not found'
       });
     }
 
@@ -456,7 +465,12 @@ const sendMoney = async (req, res) => {
       amount: validatedAmount,
       type: 'transfer_sent',
       recipientId: recipientId,
-      ipAddress: ipAddress
+      ipAddress: ipAddress,
+      recipientData: {
+        id: recipient.id,
+        name: recipient.full_name,
+        accountId: recipient.account_id
+      }
     }, {
       walletBalance: sender.wallet_balance,
       accountCreated: sender.created_at


### PR DESCRIPTION
- Fetch recipient user details before fraud check
- Pass recipient data to analyzeFraudRisk with recipientData object
- Include recipient id, full_name, and account_id
- Now fraud logs will show both sender and recipient for transfer transactions
- Fixes bug where "To:" field was missing in admin verification tab