### PR TITLE
Fix dashboard metrics queries for case-insensitive matching

### DIFF
--- a/fraudwallet/backend/src/fraudDetectionAPI.js
+++ b/fraudwallet/backend/src/fraudDetectionAPI.js
@@ -25,14 +25,14 @@ const getUserDashboardMetrics = async (req, res) => {
     const blocked = db.prepare(`
       SELECT COUNT(*) as count
       FROM fraud_logs
-      WHERE user_id = ? AND action_taken = 'BLOCK'
+      WHERE user_id = ? AND UPPER(action_taken) = 'BLOCK'
     `).get(userId);
 
     // Get high risk transactions (high + critical)
     const highRisk = db.prepare(`
       SELECT COUNT(*) as count
       FROM fraud_logs
-      WHERE user_id = ? AND risk_level IN ('high', 'critical')
+      WHERE user_id = ? AND UPPER(risk_level) IN ('HIGH', 'CRITICAL')
     `).get(userId);
 
     // Get pending appeals


### PR DESCRIPTION
Make queries case-insensitive using UPPER() function to ensure accurate counts:
- High Risk: Now correctly counts HIGH and CRITICAL risk levels
- Blocked: Now correctly counts BLOCK action regardless of case

This fixes the issue where dashboard metrics weren't updating despite data existing in the database.