### PR TITLE
Fix getUserStats query to use case-insensitive matching

### DIFF
--- a/fraudwallet/backend/src/fraud-detection/monitoring/fraudLogger.js
+++ b/fraudwallet/backend/src/fraud-detection/monitoring/fraudLogger.js
@@ -116,10 +116,10 @@ const getUserStats = async (userId) => {
         COUNT(*) as total_checks,
         AVG(risk_score) as avg_risk_score,
         MAX(risk_score) as max_risk_score,
-        SUM(CASE WHEN action_taken = 'BLOCK' THEN 1 ELSE 0 END) as blocked_count,
-        SUM(CASE WHEN action_taken = 'REVIEW' THEN 1 ELSE 0 END) as review_count,
-        SUM(CASE WHEN risk_level = 'CRITICAL' THEN 1 ELSE 0 END) as critical_count,
-        SUM(CASE WHEN risk_level = 'HIGH' THEN 1 ELSE 0 END) as high_count
+        SUM(CASE WHEN UPPER(action_taken) = 'BLOCK' THEN 1 ELSE 0 END) as blocked_count,
+        SUM(CASE WHEN UPPER(action_taken) = 'REVIEW' THEN 1 ELSE 0 END) as review_count,
+        SUM(CASE WHEN UPPER(risk_level) = 'CRITICAL' THEN 1 ELSE 0 END) as critical_count,
+        SUM(CASE WHEN UPPER(risk_level) = 'HIGH' THEN 1 ELSE 0 END) as high_count
       FROM fraud_logs
       WHERE user_id = ?
     `).get(userId);


### PR DESCRIPTION
Update getUserStats function to use UPPER() for case-insensitive comparison of action_taken and risk_level fields. This ensures accurate statistics calculation regardless of case variations in the database.

This fixes the issue where health bar showed 0 average risk score despite having actual transaction data, caused by case-sensitive string matching not finding 'BLOCK' and 'CRITICAL' values stored in uppercase.