### PR TITLE
Fix getUserStats API response to use snake_case field names

### DIFF
--- a/fraudwallet/backend/src/fraudDetectionAPI.js
+++ b/fraudwallet/backend/src/fraudDetectionAPI.js
@@ -72,13 +72,13 @@ const getUserFraudStats = async (req, res) => {
     res.status(200).json({
       success: true,
       stats: {
-        totalChecks: stats.total_checks || 0,
-        averageRiskScore: stats.avg_risk_score ? parseFloat(stats.avg_risk_score.toFixed(2)) : 0,
-        maxRiskScore: stats.max_risk_score || 0,
-        blockedTransactions: stats.blocked_count || 0,
-        reviewedTransactions: stats.review_count || 0,
-        criticalRiskCount: stats.critical_count || 0,
-        highRiskCount: stats.high_count || 0
+        total_checks: stats.total_checks || 0,
+        avg_risk_score: stats.avg_risk_score ? parseFloat(stats.avg_risk_score.toFixed(2)) : 0,
+        max_risk_score: stats.max_risk_score || 0,
+        blocked_count: stats.blocked_count || 0,
+        review_count: stats.review_count || 0,
+        critical_count: stats.critical_count || 0,
+        high_count: stats.high_count || 0
       }
     });
   } catch (error) {


### PR DESCRIPTION
Change field names in getUserFraudStats response from camelCase to snake_case to match frontend expectations:
- totalChecks → total_checks
- averageRiskScore → avg_risk_score
- maxRiskScore → max_risk_score
- blockedTransactions → blocked_count
- reviewedTransactions → review_count
- criticalRiskCount → critical_count
- highRiskCount → high_count

This fixes the health bar showing 0 values - the frontend UserStats interface expects snake_case fields, but the API was returning camelCase.