### PR TITLE
Fix critical double money bug and implement admin-first review workflow

### DIFF
--- a/fraudwallet/backend/src/fraud-detection/monitoring/fraudLogger.js
+++ b/fraudwallet/backend/src/fraud-detection/monitoring/fraudLogger.js
@@ -385,6 +385,22 @@ const createFraudLogsTable = () => {
         console.log('✅ Added revoked_reason column to fraud_logs');
       }
 
+      // Admin review status for the new workflow
+      if (!columnNames.includes('admin_review_status')) {
+        db.exec("ALTER TABLE fraud_logs ADD COLUMN admin_review_status TEXT DEFAULT 'pending'");
+        console.log('✅ Added admin_review_status column to fraud_logs');
+      }
+
+      if (!columnNames.includes('admin_reviewed_at')) {
+        db.exec("ALTER TABLE fraud_logs ADD COLUMN admin_reviewed_at DATETIME");
+        console.log('✅ Added admin_reviewed_at column to fraud_logs');
+      }
+
+      if (!columnNames.includes('admin_reviewed_by')) {
+        db.exec("ALTER TABLE fraud_logs ADD COLUMN admin_reviewed_by INTEGER");
+        console.log('✅ Added admin_reviewed_by column to fraud_logs');
+      }
+
       if (!columnNames.includes('appeal_status')) {
         db.exec("ALTER TABLE fraud_logs ADD COLUMN appeal_status TEXT DEFAULT 'none'");
         console.log('✅ Added appeal_status column to fraud_logs');


### PR DESCRIPTION
CRITICAL BUG FIX - Double Money Exploit:
- Added safety checks in releaseMoney() and returnMoney()
- Prevent double-crediting/refunding with resolution_action check
- Verify transaction type before operations
- Add audit logs for all money movements
- Check user existence before balance updates

New Admin-First Review Workflow:
1. High/Critical transactions → Money held
2. Admin reviews FIRST (Ground Truth Verification)
3. Admin marks as "legitimate" → Money auto-released to recipient
4. Admin marks as "fraud" → Money stays held, user can appeal
5. User appeals → Admin approves/rejects
6. Appeal approved → Money released
7. Appeal rejected → Money returned to sender

Database Changes:
- Added admin_review_status (pending/legitimate/fraud)
- Added admin_reviewed_at timestamp
- Added admin_reviewed_by user ID

Backend Changes:
- wallet.js: Enhanced releaseMoney() with safety checks
  * Check if already resolved
  * Verify transaction type
  * Validate user exists
  * Add audit log entry
- wallet.js: Enhanced returnMoney() with safety checks
  * Same protections as releaseMoney()
  * Prevents double-refunding
- fraudLogger.js: Added admin review tracking fields
- fraudDetectionAPI.js: Updated verifyGroundTruth() to:
  * Update admin_review_status
  * Auto-release money if marked legitimate (False Positive)
  * Keep held if marked fraud (allows user appeal)

This prevents the exploit where both sender and recipient had money after release.

Still TODO (Phase 2):
- Block user appeals until admin reviews
- Update frontend to show admin review status
- Update getHeldTransactions to include admin review info