### PR TITLE
Fix fraud_log_id linking issue preventing automatic money release

### DIFF
--- a/fraudwallet/backend/fix-admin-review.js
+++ b/fraudwallet/backend/fix-admin-review.js
@@ -1,0 +1,97 @@
+/**
+ * Fix admin review and release money
+ * Run this with: node fix-admin-review.js <transactionId>
+ */
+
+const db = require('./src/database');
+const wallet = require('./src/wallet');
+
+const transactionId = process.argv[2];
+
+if (!transactionId) {
+  console.error('Usage: node fix-admin-review.js <transactionId>');
+  console.log('\nExample: node fix-admin-review.js 140');
+  process.exit(1);
+}
+
+async function fixAdminReview() {
+  console.log(`\n🔍 Checking Transaction #${transactionId}\n`);
+
+  // Get transaction
+  const transaction = db.prepare('SELECT * FROM transactions WHERE id = ?').get(transactionId);
+
+  if (!transaction) {
+    console.log('❌ Transaction not found!');
+    return;
+  }
+
+  console.log('✅ Transaction found:');
+  console.log('   User ID:', transaction.user_id);
+  console.log('   Amount:', transaction.amount);
+  console.log('   Money Status:', transaction.money_status);
+  console.log('   Fraud Log ID:', transaction.fraud_log_id);
+
+  // Find fraud log for this user and amount
+  const fraudLog = db.prepare(`
+    SELECT * FROM fraud_logs
+    WHERE user_id = ? AND amount = ?
+    ORDER BY created_at DESC
+    LIMIT 1
+  `).get(transaction.user_id, transaction.amount);
+
+  if (!fraudLog) {
+    console.log('\n❌ No fraud log found for this transaction!');
+    console.log('   This transaction might not have triggered fraud detection.');
+    return;
+  }
+
+  console.log('\n✅ Fraud log found:');
+  console.log('   Fraud Log ID:', fraudLog.id);
+  console.log('   Risk Score:', fraudLog.risk_score);
+  console.log('   Admin Review Status:', fraudLog.admin_review_status);
+  console.log('   Ground Truth:', fraudLog.ground_truth);
+
+  // Link transaction to fraud log if not linked
+  if (!transaction.fraud_log_id) {
+    console.log('\n🔗 Linking transaction to fraud log...');
+    db.prepare('UPDATE transactions SET fraud_log_id = ? WHERE id = ?').run(fraudLog.id, transactionId);
+    console.log('✅ Linked!');
+  }
+
+  // Check if admin marked as legitimate
+  if (fraudLog.admin_review_status === 'legitimate' || fraudLog.ground_truth === 'legitimate') {
+    console.log('\n💰 Admin marked as LEGITIMATE - Releasing money...');
+
+    try {
+      const result = await wallet.releaseMoney(
+        parseInt(transactionId),
+        fraudLog.admin_reviewed_by || 1,
+        'Admin marked as legitimate (manual fix)'
+      );
+
+      console.log('✅ SUCCESS! Money released:');
+      console.log('   Amount:', result.amount);
+      console.log('   Recipient ID:', result.recipientId);
+
+      // Verify
+      const updated = db.prepare('SELECT money_status FROM transactions WHERE id = ?').get(transactionId);
+      console.log('   New Status:', updated.money_status);
+
+    } catch (error) {
+      console.error('\n❌ ERROR releasing money:');
+      console.error('   ', error.message);
+    }
+  } else {
+    console.log('\n⚠️  Admin has NOT marked this as legitimate yet.');
+    console.log('   Admin Review Status:', fraudLog.admin_review_status);
+    console.log('   Ground Truth:', fraudLog.ground_truth);
+  }
+}
+
+fixAdminReview().then(() => {
+  console.log('\n✅ Done\n');
+  process.exit(0);
+}).catch(err => {
+  console.error('\n❌ Error:', err);
+  process.exit(1);
+});

--- a/fraudwallet/backend/src/fraud-detection/index.js
+++ b/fraudwallet/backend/src/fraud-detection/index.js
@@ -156,7 +156,10 @@ const analyzeFraudRisk = async (transaction, userContext = {}) => {
     };
 
     // Log for monitoring and academic metrics tracking
-    await fraudLogger.logFraudCheck(transaction, result);
+    const logId = await fraudLogger.logFraudCheck(transaction, result);
+
+    // Add logId to result so it can be saved with the transaction
+    result.logId = logId;
 
     console.log(`   ✅ AI Detection complete (${result.executionTime}ms)\n`);
 

--- a/fraudwallet/backend/src/fraud-detection/monitoring/fraudLogger.js
+++ b/fraudwallet/backend/src/fraud-detection/monitoring/fraudLogger.js
@@ -7,6 +7,7 @@ const db = require('../../database');
  * Log a fraud check result
  * @param {Object} transaction - Transaction details
  * @param {Object} fraudResult - Fraud detection result
+ * @returns {number|null} The fraud log ID, or null if logging failed
  */
 const logFraudCheck = async (transaction, fraudResult) => {
   try {
@@ -24,7 +25,7 @@ const logFraudCheck = async (transaction, fraudResult) => {
     const recipientData = transaction.recipientData || {};
 
     // Insert fraud check log with AI, location, and recipient data
-    db.prepare(`
+    const result = db.prepare(`
       INSERT INTO fraud_logs (
         user_id,
         transaction_type,
@@ -79,6 +80,8 @@ const logFraudCheck = async (transaction, fraudResult) => {
       recipientData.accountId || null
     );
 
+    const logId = result.lastInsertRowid;
+
     // Log to console for real-time monitoring
     if (fraudResult.riskScore >= 60) {
       console.log(`🚨 HIGH RISK TRANSACTION DETECTED`);
@@ -99,8 +102,11 @@ const logFraudCheck = async (transaction, fraudResult) => {
       console.log(`⚠️  MEDIUM RISK: User ${transaction.userId}, Score: ${fraudResult.riskScore}/100 (${fraudResult.detectionMethod || 'rules'})`);
     }
 
+    return logId;
+
   } catch (error) {
     console.error('Fraud logging error:', error);
+    return null;
   }
 };
 


### PR DESCRIPTION
PROBLEM:
- Admin marks transactions as "Legitimate" but money stays held
- fraud_log_id field was null in transactions table
- verifyGroundTruth() couldn't find held transactions to release money

ROOT CAUSE:
- fraudLogger.logFraudCheck() inserted fraud logs but didn't return the log ID
- Fraud detection result had no logId property
- wallet.js set fraud_log_id to null (fraudCheck.logId || null)

SOLUTION:
1. Updated fraudLogger.logFraudCheck() to return the inserted row ID
2. Updated fraud detection index.js to capture logId and add to result
3. Now wallet.js line 592 properly sets fraud_log_id when creating transactions

IMPACT:
- Future transactions will have proper fraud_log_id linking
- Auto-release on admin approval will work correctly
- Existing transactions need fix-admin-review.js to repair links

DIAGNOSTIC TOOL:
- Added fix-admin-review.js to repair existing transactions
- Finds fraud log by user_id + amount
- Links transaction to fraud_log_id
- Releases money if admin marked as legitimate