### PR TITLE
Temporarily revert to local fraud detection - fix startup error

### DIFF
--- a/fraudwallet/backend/src/server.js
+++ b/fraudwallet/backend/src/server.js
@@ -83,8 +83,9 @@ app.get('/api/wallet/transactions', verifyToken, wallet.getTransactionHistory);
 app.get('/api/wallet/held-transactions', verifyToken, wallet.getHeldTransactions);
 app.post('/api/wallet/send', verifyToken, wallet.sendMoney);
 
-// Fraud Detection routes (protected) - Now proxied to fraud microservice
-const fraudAPI = require('./fraudDetectionAPIProxy'); // Changed to proxy
+// Fraud Detection routes (protected)
+// TEMPORARY: Using local fraud detection until fraud service is ready
+const fraudAPI = require('./fraudDetectionAPI'); // Using local for now
 app.get('/api/fraud/user-stats', verifyToken, fraudAPI.getUserFraudStats);
 app.get('/api/fraud/system-metrics', verifyToken, fraudAPI.getSystemMetrics);
 app.get('/api/fraud/system-health', verifyToken, fraudAPI.getSystemHealth);

--- a/fraudwallet/backend/src/wallet.js
+++ b/fraudwallet/backend/src/wallet.js
@@ -1,7 +1,8 @@
 // Wallet and Stripe payment management
 const db = require('./database');
 const stripe = require('stripe')(process.env.STRIPE_SECRET_KEY);
-const fraudDetection = require('./fraudServiceClient'); // Changed to call fraud microservice
+// TEMPORARY: Using local fraud detection until service is ready
+const fraudDetection = require('./fraud-detection'); // Using local for now
 
 // Amount validation constants
 const AMOUNT_LIMITS = {


### PR DESCRIPTION
The proxy approach was causing undefined route handlers. Reverting to local fraud-detection module for immediate testing. Will re-enable microservice proxy after testing fraud service standalone.

This allows:
- Backend to start without errors
- Test fraud service independently
- Then connect them once both work separately