### PR TITLE
Add forgot passcode functionality with OTP verification

### DIFF
--- a/fraudwallet/backend/src/server.js
+++ b/fraudwallet/backend/src/server.js
@@ -64,6 +64,9 @@ app.post('/api/user/passcode/set', verifyToken, passcodeAPI.setUserPasscode);
 app.post('/api/user/passcode/verify', verifyToken, passcodeAPI.verifyUserPasscode);
 app.post('/api/user/passcode/change', verifyToken, passcodeAPI.changeUserPasscode);
 app.get('/api/user/passcode/status', verifyToken, passcodeAPI.getUserPasscodeStatus);
+app.post('/api/user/passcode/forgot', verifyToken, passcodeAPI.forgotPasscode);
+app.post('/api/user/passcode/verify-otp', verifyToken, passcodeAPI.verifyPasscodeOtp);
+app.post('/api/user/passcode/reset', verifyToken, passcodeAPI.resetUserPasscode);
 
 // Payment routes (protected)
 app.post('/api/payment/lookup-recipient', verifyToken, user.lookupRecipient);


### PR DESCRIPTION
Backend:
- Add resetPasscode function in passcode.js
- Add forgotPasscode endpoint to send OTP email
- Add verifyPasscodeOtp endpoint to verify OTP code
- Add resetUserPasscode endpoint to reset passcode after verification
- Add routes for forgot passcode flow in server.js

Frontend:
- Update PasscodeDialog with "Forgot Passcode?" link
- Add forgot passcode flow: OTP entry -> new passcode -> confirm
- Integrated with existing verify mode dialog

Flow:
1. User clicks "Forgot Passcode?" in verify dialog
2. System sends OTP to user's registered email
3. User enters 6-digit OTP code
4. If valid, user enters new passcode and confirms
5. Passcode is reset and lockout is cleared

https://claude.ai/code/session_01WYEnfrAFHU5mhKsnVmGqxm