### PR TITLE
Add admin function to reset user transaction passcode

### DIFF
--- a/fraudwallet/backend/src/server.js
+++ b/fraudwallet/backend/src/server.js
@@ -147,6 +147,7 @@ app.get('/api/admin/users', verifyAdminToken, adminAPI.getAllUsers);
 app.get('/api/admin/users/:userId', verifyAdminToken, adminAPI.getUserById);
 app.patch('/api/admin/users/:userId/status', verifyAdminToken, adminAPI.updateUserStatus);
 app.patch('/api/admin/users/:userId/password', verifyAdminToken, adminAPI.resetUserPassword);
+app.patch('/api/admin/users/:userId/passcode', verifyAdminToken, adminAPI.resetUserPasscode);
 
 // Initialize system health monitoring
 const systemHealthMonitor = require('./monitoring/systemHealthMonitor');


### PR DESCRIPTION
Backend:
- Add resetUserPasscode endpoint in adminAPI.js
- Add route /api/admin/users/:userId/passcode in server.js
- Validates 6-digit passcode format
- Clears any passcode lockout when resetting

Frontend:
- Add passcode reset UI in user-management-tab.tsx
- Input field accepts only 6 digits
- Shows Lock icon for passcode reset button

https://claude.ai/code/session_01WYEnfrAFHU5mhKsnVmGqxm